### PR TITLE
Improve OpenRouter usage display

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -228,57 +228,6 @@ func (m Model) codexSection() string {
 	return b.String()
 }
 
-func (m Model) orSection() string {
-	var b strings.Builder
-	b.WriteString(sectionStyle.Render(" OpenRouter"))
-	b.WriteByte('\n')
-
-	if m.orUsage == nil && m.orErr == "" {
-		b.WriteString(dimStyle.Render("  Loading..."))
-		b.WriteByte('\n')
-		return b.String()
-	}
-
-	if m.orErr != "" {
-		c := yellow
-		if m.orUsage == nil {
-			c = red
-		}
-		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.orErr, m.orRetries, maxRetries)))
-		b.WriteByte('\n')
-		if m.orUsage == nil {
-			return b.String()
-		}
-	}
-
-	u := m.orUsage
-	bw := m.barWidth()
-
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  Key: %s", u.Key.Label)))
-	b.WriteByte('\n')
-	b.WriteByte('\n')
-
-	if u.Key.Limit > 0 {
-		usedPct := (u.Key.Limit - u.Key.LimitRemaining) / u.Key.Limit * 100
-		b.WriteString(renderBar("Credit Limit", usedPct, bw,
-			fmt.Sprintf("$%.4f remaining (resets %s)", u.Key.LimitRemaining, u.Key.LimitReset),
-		))
-		b.WriteByte('\n')
-	}
-
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  Usage — Daily: $%.4f | Weekly: $%.4f | Monthly: $%.4f",
-		u.Key.UsageDaily, u.Key.UsageWeekly, u.Key.UsageMonthly)))
-	b.WriteByte('\n')
-
-	if u.Credits != nil {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  Credits — Total: $%.4f | Used: $%.4f | Remaining: $%.4f",
-			u.Credits.Total, u.Credits.Used, u.Credits.Remaining)))
-		b.WriteByte('\n')
-	}
-
-	b.WriteByte('\n')
-	return b.String()
-}
 
 func (m Model) footer() string {
 	var ts string

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -64,7 +64,7 @@ func (m Model) orSection() string {
 	if u.Key.IsManagementKey {
 		b.WriteString(renderORCredits(u))
 		b.WriteString(renderORActivity(u))
-		b.WriteString(renderORModels(u))
+		b.WriteString(m.renderORModels(u))
 		b.WriteString(renderORKeys(u))
 	}
 
@@ -99,26 +99,62 @@ func renderORActivity(u *openrouter.Usage) string {
 	return b.String()
 }
 
-func renderORModels(u *openrouter.Usage) string {
+func (m Model) renderORModels(u *openrouter.Usage) string {
 	if u.Activity == nil || len(u.Activity.Models) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteByte('\n')
 	b.WriteString("  " + labelStyle.Render("Top Models") + "\n")
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-42s  %10s  %9s", "Model", "Spend", "Requests")))
-	b.WriteByte('\n')
 
 	models := u.Activity.Models
 	if len(models) > maxModels {
 		models = models[:maxModels]
 	}
+
+	maxSpend := models[0].Spend
+	barWidth := m.modelBarWidth()
 	for _, m := range models {
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-42s  $%9.4f  %9.0f",
-			truncate(m.Model, 42), m.Spend, m.Requests)))
+		label := truncate(m.Model, 28)
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-28s  $%9.4f", label, m.Spend)))
+		b.WriteByte('\n')
+		b.WriteString(fmt.Sprintf("  %s  %s\n",
+			renderModelBar(m.Spend, maxSpend, barWidth),
+			dimStyle.Render(fmt.Sprintf("%.0f req", m.Requests)),
+		))
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+func (m Model) modelBarWidth() int {
+	w := m.width - 26
+	if w < 12 {
+		return 12
+	}
+	if w > 44 {
+		return 44
+	}
+	return w
+}
+
+func renderModelBar(spend, maxSpend float64, width int) string {
+	if width < 1 {
+		width = 1
+	}
+	filled := width
+	if maxSpend > 0 {
+		filled = int(spend / maxSpend * float64(width))
+	}
+	if spend > 0 && filled == 0 {
+		filled = 1
+	}
+	if filled > width {
+		filled = width
+	}
+
+	return modelBarFilledStyle.Render(strings.Repeat("█", filled)) +
+		modelBarEmptyStyle.Render(strings.Repeat("░", width-filled))
 }
 
 func renderORKeys(u *openrouter.Usage) string {

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -1,0 +1,166 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lwlee2608/tokentop/pkg/openrouter"
+)
+
+const (
+	maxModels = 8
+	maxKeys   = 10
+)
+
+func (m Model) orSection() string {
+	var b strings.Builder
+	b.WriteString(sectionStyle.Render(" OpenRouter"))
+	b.WriteByte('\n')
+
+	if m.orUsage == nil && m.orErr == "" {
+		b.WriteString(dimStyle.Render("  Loading..."))
+		b.WriteByte('\n')
+		return b.String()
+	}
+
+	if m.orErr != "" {
+		c := yellow
+		if m.orUsage == nil {
+			c = red
+		}
+		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.orErr, m.orRetries, maxRetries)))
+		b.WriteByte('\n')
+		if m.orUsage == nil {
+			return b.String()
+		}
+	}
+
+	u := m.orUsage
+	bw := m.barWidth()
+
+	keyLabel := u.Key.Label
+	switch {
+	case u.Key.IsFreeTier:
+		keyLabel += " (free tier)"
+	case u.Key.IsManagementKey:
+		keyLabel += " (management)"
+	}
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  Key: %s", keyLabel)))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	if u.Key.Limit > 0 {
+		usedPct := (u.Key.Limit - u.Key.LimitRemaining) / u.Key.Limit * 100
+		b.WriteString(renderBar("Credit Limit", usedPct, bw,
+			fmt.Sprintf("$%.4f remaining (resets %s)", u.Key.LimitRemaining, u.Key.LimitReset),
+		))
+		b.WriteByte('\n')
+	}
+
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  Usage — Daily: $%.4f | Weekly: $%.4f | Monthly: $%.4f",
+		u.Key.UsageDaily, u.Key.UsageWeekly, u.Key.UsageMonthly)))
+	b.WriteByte('\n')
+
+	if u.Key.IsManagementKey {
+		b.WriteString(renderORCredits(u))
+		b.WriteString(renderORActivity(u))
+		b.WriteString(renderORModels(u))
+		b.WriteString(renderORKeys(u))
+	}
+
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func renderORCredits(u *openrouter.Usage) string {
+	if u.Credits == nil {
+		return ""
+	}
+	return dimStyle.Render(fmt.Sprintf("\n  Credits — Total: $%.4f | Used: $%.4f | Remaining: $%.4f",
+		u.Credits.Total, u.Credits.Used, u.Credits.Remaining)) + "\n"
+}
+
+func renderORActivity(u *openrouter.Usage) string {
+	if u.Activity == nil {
+		return ""
+	}
+	t := u.Activity.Totals
+	var b strings.Builder
+	b.WriteByte('\n')
+	b.WriteString("  " + labelStyle.Render("Activity") + "\n")
+
+	line := fmt.Sprintf("  Spend: $%.4f | Requests: %.0f | Tokens: %s prompt + %s completion",
+		t.Spend, t.Requests, formatTokens(t.PromptTokens), formatTokens(t.CompletionTokens))
+	if t.ReasoningTokens > 0 {
+		line += fmt.Sprintf(" + %s reasoning", formatTokens(t.ReasoningTokens))
+	}
+	b.WriteString(dimStyle.Render(line))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func renderORModels(u *openrouter.Usage) string {
+	if u.Activity == nil || len(u.Activity.Models) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteByte('\n')
+	b.WriteString("  " + labelStyle.Render("Top Models") + "\n")
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-42s  %10s  %9s", "Model", "Spend", "Requests")))
+	b.WriteByte('\n')
+
+	models := u.Activity.Models
+	if len(models) > maxModels {
+		models = models[:maxModels]
+	}
+	for _, m := range models {
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-42s  $%9.4f  %9.0f",
+			truncate(m.Model, 42), m.Spend, m.Requests)))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func renderORKeys(u *openrouter.Usage) string {
+	if len(u.APIKeys) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteByte('\n')
+	b.WriteString("  " + labelStyle.Render("API Keys") + "\n")
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-30s  %10s  %10s  %10s", "Key", "Daily", "Weekly", "Monthly")))
+	b.WriteByte('\n')
+
+	keys := u.APIKeys
+	if len(keys) > maxKeys {
+		keys = keys[:maxKeys]
+	}
+	for _, k := range keys {
+		name := k.Label
+		if name == "" {
+			name = k.Name
+		}
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-30s  $%9.4f  $%9.4f  $%9.4f",
+			truncate(name, 30), k.UsageDaily, k.UsageWeekly, k.UsageMonthly)))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func formatTokens(n float64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", n/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fK", n/1_000)
+	default:
+		return fmt.Sprintf("%.0f", n)
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -47,9 +47,9 @@ func (m Model) orSection() string {
 	}
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Key: %s", keyLabel)))
 	b.WriteByte('\n')
-	b.WriteByte('\n')
 
 	if u.Key.Limit > 0 {
+		b.WriteByte('\n')
 		usedPct := (u.Key.Limit - u.Key.LimitRemaining) / u.Key.Limit * 100
 		b.WriteString(renderBar("Credit Limit", usedPct, bw,
 			fmt.Sprintf("$%.4f remaining (resets %s)", u.Key.LimitRemaining, u.Key.LimitReset),
@@ -62,8 +62,7 @@ func (m Model) orSection() string {
 	b.WriteByte('\n')
 
 	if u.Key.IsManagementKey {
-		b.WriteString(renderORCredits(u))
-		b.WriteString(renderORActivity(u))
+		b.WriteString(renderORSummary(u))
 		b.WriteString(m.renderORModels(u))
 		b.WriteString(renderORKeys(u))
 	}
@@ -72,29 +71,26 @@ func (m Model) orSection() string {
 	return b.String()
 }
 
-func renderORCredits(u *openrouter.Usage) string {
-	if u.Credits == nil {
+func renderORSummary(u *openrouter.Usage) string {
+	if u.Credits == nil && u.Activity == nil {
 		return ""
 	}
-	return dimStyle.Render(fmt.Sprintf("\n  Credits — Total: $%.4f | Used: $%.4f | Remaining: $%.4f",
-		u.Credits.Total, u.Credits.Used, u.Credits.Remaining)) + "\n"
-}
-
-func renderORActivity(u *openrouter.Usage) string {
-	if u.Activity == nil {
-		return ""
-	}
-	t := u.Activity.Totals
 	var b strings.Builder
 	b.WriteByte('\n')
-	b.WriteString("  " + labelStyle.Render("Activity") + "\n")
-
-	line := fmt.Sprintf("  Spend: $%.4f | Requests: %.0f | Tokens: %s prompt + %s completion",
-		t.Spend, t.Requests, formatTokens(t.PromptTokens), formatTokens(t.CompletionTokens))
-	if t.ReasoningTokens > 0 {
-		line += fmt.Sprintf(" + %s reasoning", formatTokens(t.ReasoningTokens))
+	parts := make([]string, 0, 3)
+	if u.Credits != nil {
+		parts = append(parts, fmt.Sprintf("Credits $%.2f/$%.2f left", u.Credits.Remaining, u.Credits.Total))
 	}
-	b.WriteString(dimStyle.Render(line))
+	if u.Activity != nil {
+		t := u.Activity.Totals
+		parts = append(parts, fmt.Sprintf("Spend $%.2f | %.0f req", t.Spend, t.Requests))
+		tokens := fmt.Sprintf("%s in + %s out", formatTokens(t.PromptTokens), formatTokens(t.CompletionTokens))
+		if t.ReasoningTokens > 0 {
+			tokens += fmt.Sprintf(" + %s reason", formatTokens(t.ReasoningTokens))
+		}
+		parts = append(parts, tokens)
+	}
+	b.WriteString(dimStyle.Render("  " + strings.Join(parts, " | ")))
 	b.WriteByte('\n')
 	return b.String()
 }
@@ -114,31 +110,30 @@ func (m Model) renderORModels(u *openrouter.Usage) string {
 
 	maxSpend := models[0].Spend
 	barWidth := m.modelBarWidth()
-	for _, m := range models {
-		label := truncate(m.Model, 28)
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-28s  $%9.4f", label, m.Spend)))
-		b.WriteByte('\n')
-		b.WriteString(fmt.Sprintf("  %s  %s\n",
-			renderModelBar(m.Spend, maxSpend, barWidth),
-			dimStyle.Render(fmt.Sprintf("%.0f req", m.Requests)),
+	for i, model := range models {
+		label := truncate(model.Model, 22)
+		b.WriteString(fmt.Sprintf("  %s  %s  %s  %s\n",
+			dimStyle.Render(fmt.Sprintf("%-22s", label)),
+			dimStyle.Render(fmt.Sprintf("$%7.2f", model.Spend)),
+			renderModelBar(model.Spend, maxSpend, barWidth, i),
+			dimStyle.Render(fmt.Sprintf("%4.0f req", model.Requests)),
 		))
-		b.WriteByte('\n')
 	}
 	return b.String()
 }
 
 func (m Model) modelBarWidth() int {
-	w := m.width - 26
-	if w < 12 {
-		return 12
+	w := m.width - 44
+	if w < 8 {
+		return 8
 	}
-	if w > 44 {
-		return 44
+	if w > 28 {
+		return 28
 	}
 	return w
 }
 
-func renderModelBar(spend, maxSpend float64, width int) string {
+func renderModelBar(spend, maxSpend float64, width int, colorIndex int) string {
 	if width < 1 {
 		width = 1
 	}
@@ -153,7 +148,7 @@ func renderModelBar(spend, maxSpend float64, width int) string {
 		filled = width
 	}
 
-	return modelBarFilledStyle.Render(strings.Repeat("█", filled)) +
+	return modelBarFilledStyle(colorIndex).Render(strings.Repeat("█", filled)) +
 		modelBarEmptyStyle.Render(strings.Repeat("░", width-filled))
 }
 
@@ -164,8 +159,6 @@ func renderORKeys(u *openrouter.Usage) string {
 	var b strings.Builder
 	b.WriteByte('\n')
 	b.WriteString("  " + labelStyle.Render("API Keys") + "\n")
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-30s  %10s  %10s  %10s", "Key", "Daily", "Weekly", "Monthly")))
-	b.WriteByte('\n')
 
 	keys := u.APIKeys
 	if len(keys) > maxKeys {
@@ -176,8 +169,8 @@ func renderORKeys(u *openrouter.Usage) string {
 		if name == "" {
 			name = k.Name
 		}
-		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-30s  $%9.4f  $%9.4f  $%9.4f",
-			truncate(name, 30), k.UsageDaily, k.UsageWeekly, k.UsageMonthly)))
+		b.WriteString(dimStyle.Render(fmt.Sprintf("  %-18s d:$%6.2f  w:$%6.2f  m:$%6.2f",
+			truncate(name, 18), k.UsageDaily, k.UsageWeekly, k.UsageMonthly)))
 		b.WriteByte('\n')
 	}
 	return b.String()

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -6,6 +6,7 @@ const barPadding = 30 // space taken by "  Used: XXX%  " + " XXX% free"
 
 var (
 	green  = lipgloss.Color("2")
+	cyan   = lipgloss.Color("6")
 	yellow = lipgloss.Color("3")
 	red    = lipgloss.Color("1")
 	white  = lipgloss.Color("15")
@@ -22,6 +23,11 @@ func barFilledStyle(c lipgloss.Color) lipgloss.Style {
 }
 
 var barEmptyStyle = lipgloss.NewStyle().Background(gray)
+
+var (
+	modelBarFilledStyle = lipgloss.NewStyle().Foreground(cyan)
+	modelBarEmptyStyle  = lipgloss.NewStyle().Foreground(gray)
+)
 
 func pctStyle(c lipgloss.Color) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(c)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -7,6 +7,9 @@ const barPadding = 30 // space taken by "  Used: XXX%  " + " XXX% free"
 var (
 	green  = lipgloss.Color("2")
 	cyan   = lipgloss.Color("6")
+	blue   = lipgloss.Color("12")
+	orange = lipgloss.Color("208")
+	pink   = lipgloss.Color("205")
 	yellow = lipgloss.Color("3")
 	red    = lipgloss.Color("1")
 	white  = lipgloss.Color("15")
@@ -24,10 +27,13 @@ func barFilledStyle(c lipgloss.Color) lipgloss.Style {
 
 var barEmptyStyle = lipgloss.NewStyle().Background(gray)
 
-var (
-	modelBarFilledStyle = lipgloss.NewStyle().Foreground(cyan)
-	modelBarEmptyStyle  = lipgloss.NewStyle().Foreground(gray)
-)
+var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
+
+var modelBarColors = []lipgloss.Color{cyan, blue, green, yellow, orange, pink, red}
+
+func modelBarFilledStyle(i int) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(modelBarColors[i%len(modelBarColors)])
+}
 
 func pctStyle(c lipgloss.Color) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(c)


### PR DESCRIPTION
## Summary
- add a dedicated OpenRouter usage section to the TUI for management keys
- replace the top models table with a compact colored bar chart that is easier to scan in the terminal
- condense credits, activity, and API key details so more usage information fits on screen