### PR TITLE
Add file-backed slog logging

### DIFF
--- a/cmd/tokentop/logger.go
+++ b/cmd/tokentop/logger.go
@@ -9,6 +9,10 @@ import (
 )
 
 func initLogger(logLevel, logPath string) (func() error, error) {
+	if strings.ToUpper(strings.TrimSpace(logLevel)) == "OFF" {
+		return func() error { return nil }, nil
+	}
+
 	level := parseLogLevel(logLevel)
 
 	if strings.TrimSpace(logPath) == "" {

--- a/cmd/tokentop/logger.go
+++ b/cmd/tokentop/logger.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func initLogger(logLevel, logPath string) (func() error, error) {
+	level := parseLogLevel(logLevel)
+
+	if strings.TrimSpace(logPath) == "" {
+		var err error
+		logPath, err = defaultLogPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
+	}
+
+	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+
+	handler := slog.NewTextHandler(file, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
+
+	return file.Close, nil
+}
+
+func parseLogLevel(logLevel string) slog.Level {
+	switch strings.ToUpper(strings.TrimSpace(logLevel)) {
+	case "ERROR":
+		return slog.LevelError
+	case "WARN", "WARNING":
+		return slog.LevelWarn
+	case "DEBUG":
+		return slog.LevelDebug
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func defaultLogPath() (string, error) {
+	stateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME"))
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+
+	return filepath.Join(stateHome, "tokentop", "tokentop.log"), nil
+}

--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/lwlee2608/adder"
 	"github.com/lwlee2608/tokentop/internal/config"
 	"github.com/lwlee2608/tokentop/internal/tui"
 	"github.com/lwlee2608/tokentop/pkg/codex"
@@ -46,6 +47,13 @@ func main() {
 	case *allProviders:
 		cfg.Providers.Codex.Enabled = true
 		cfg.Providers.OpenRouter.Enabled = true
+	}
+
+	if parseLogLevel(cfg.Log.Level) == slog.LevelDebug {
+		configJSON, err := adder.PrettyJSON(cfg)
+		if err == nil {
+			slog.Debug("config loaded", "config", configJSON)
+		}
 	}
 
 	var codexAuth *codex.Auth

--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -26,6 +27,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	closeLogger, err := initLogger(cfg.Log.Level, cfg.Log.Path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: init logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = closeLogger() }()
+
+	slog.Info("starting tokentop", "version", AppVersion)
+
 	switch {
 	case *onlyCodex:
 		cfg.Providers.Codex.Enabled = true
@@ -42,9 +52,11 @@ func main() {
 	if cfg.Providers.Codex.Enabled {
 		auth, err := codex.LoadAuth()
 		if err != nil {
+			slog.Warn("codex auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: codex: %v\n", err)
 		} else {
 			codexAuth = auth
+			slog.Info("codex provider enabled")
 		}
 	}
 
@@ -52,22 +64,28 @@ func main() {
 	if cfg.Providers.OpenRouter.Enabled {
 		auth, err := openrouter.LoadAuth()
 		if err != nil {
+			slog.Warn("openrouter auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: openrouter: %v\n", err)
 		} else {
 			orAuth = auth
+			slog.Info("openrouter provider enabled")
 		}
 	}
 
 	// TODO: anthropic provider (not yet implemented)
 
 	if codexAuth == nil && orAuth == nil {
+		slog.Error("no providers available")
 		fmt.Fprintf(os.Stderr, "Error: no providers available\n")
 		os.Exit(1)
 	}
 
 	p := tea.NewProgram(tui.New(codexAuth, orAuth, AppVersion), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
+		slog.Error("tui exited with error", "error", err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	slog.Info("tokentop exited")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,13 @@ import (
 )
 
 type Config struct {
+	Log       LogConfig       `mapstructure:"log"`
 	Providers ProvidersConfig `mapstructure:"providers"`
+}
+
+type LogConfig struct {
+	Level string `mapstructure:"level"`
+	Path  string `mapstructure:"path"`
 }
 
 type ProvidersConfig struct {

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -1,3 +1,7 @@
+log:
+  level: info
+  path: ""
+
 providers:
   codex:
     enabled: true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 	"time"
@@ -81,6 +82,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		m.codexRetries = 0
 		m.orRetries = 0
+		slog.Debug("starting usage refresh")
 		var cmds []tea.Cmd
 		if m.codexAuth != nil {
 			cmds = append(cmds, fetchCodexUsage(m.codexAuth))
@@ -100,29 +102,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case codexUsageMsg:
 		if msg.err != nil {
 			m.codexErr = msg.err.Error()
+			slog.Warn("codex usage refresh failed", "error", msg.err, "retry", m.codexRetries, "max_retries", maxRetries)
 			if m.codexRetries < maxRetries {
 				m.codexRetries++
+				slog.Info("scheduling codex usage retry", "retry", m.codexRetries, "delay", retryDelay.String())
 				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return codexRetryMsg{} })
 			}
+			slog.Error("codex usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
 		} else {
 			m.codexUsage = msg.usage
 			m.codexErr = ""
 			m.codexRetries = 0
 			m.lastFetch = time.Now()
+			slog.Debug("codex usage refresh succeeded")
 		}
 
 	case orUsageMsg:
 		if msg.err != nil {
 			m.orErr = msg.err.Error()
+			slog.Warn("openrouter usage refresh failed", "error", msg.err, "retry", m.orRetries, "max_retries", maxRetries)
 			if m.orRetries < maxRetries {
 				m.orRetries++
+				slog.Info("scheduling openrouter usage retry", "retry", m.orRetries, "delay", retryDelay.String())
 				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return orRetryMsg{} })
 			}
+			slog.Error("openrouter usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
 		} else {
 			m.orUsage = msg.usage
 			m.orErr = ""
 			m.orRetries = 0
 			m.lastFetch = time.Now()
+			slog.Debug("openrouter usage refresh succeeded")
 		}
 	}
 	return m, nil
@@ -227,7 +237,6 @@ func (m Model) codexSection() string {
 	b.WriteByte('\n')
 	return b.String()
 }
-
 
 func (m Model) footer() string {
 	var ts string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,7 +105,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			slog.Warn("codex usage refresh failed", "error", msg.err, "retry", m.codexRetries, "max_retries", maxRetries)
 			if m.codexRetries < maxRetries {
 				m.codexRetries++
-				slog.Info("scheduling codex usage retry", "retry", m.codexRetries, "delay", retryDelay.String())
+				slog.Debug("scheduling codex usage retry", "retry", m.codexRetries, "delay", retryDelay.String())
 				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return codexRetryMsg{} })
 			}
 			slog.Error("codex usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
@@ -123,7 +123,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			slog.Warn("openrouter usage refresh failed", "error", msg.err, "retry", m.orRetries, "max_retries", maxRetries)
 			if m.orRetries < maxRetries {
 				m.orRetries++
-				slog.Info("scheduling openrouter usage retry", "retry", m.orRetries, "delay", retryDelay.String())
+				slog.Debug("scheduling openrouter usage retry", "retry", m.orRetries, "delay", retryDelay.String())
 				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return orRetryMsg{} })
 			}
 			slog.Error("openrouter usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)

--- a/pkg/codex/usage.go
+++ b/pkg/codex/usage.go
@@ -4,22 +4,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 )
 
 type Usage struct {
-	PlanType            string         `json:"plan_type"`
-	RateLimit           RateLimit      `json:"rate_limit"`
-	CodeReviewRateLimit RateLimit      `json:"code_review_rate_limit"`
-	Credits             UsageCredits   `json:"credits"`
+	PlanType            string       `json:"plan_type"`
+	RateLimit           RateLimit    `json:"rate_limit"`
+	CodeReviewRateLimit RateLimit    `json:"code_review_rate_limit"`
+	Credits             UsageCredits `json:"credits"`
 }
 
 type RateLimit struct {
-	Allowed         bool          `json:"allowed"`
-	LimitReached    bool          `json:"limit_reached"`
-	PrimaryWindow   *UsageWindow  `json:"primary_window"`
-	SecondaryWindow *UsageWindow  `json:"secondary_window"`
+	Allowed         bool         `json:"allowed"`
+	LimitReached    bool         `json:"limit_reached"`
+	PrimaryWindow   *UsageWindow `json:"primary_window"`
+	SecondaryWindow *UsageWindow `json:"secondary_window"`
 }
 
 type UsageWindow struct {
@@ -50,8 +51,12 @@ type UsageCredits struct {
 }
 
 func FetchUsage(auth *Auth) (*Usage, error) {
+	logger := slog.With("provider", "codex", "endpoint", "/backend-api/wham/usage")
+	started := time.Now()
+
 	req, err := http.NewRequest("GET", "https://chatgpt.com/backend-api/wham/usage", nil)
 	if err != nil {
+		logger.Error("build request failed", "error", err)
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+auth.Tokens.AccessToken)
@@ -60,23 +65,29 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
+		logger.Warn("request failed", "error", err, "duration_ms", time.Since(started).Milliseconds())
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Warn("read response failed", "error", err, "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
 	var usage Usage
 	if err := json.Unmarshal(body, &usage); err != nil {
+		logger.Warn("parse response failed", "error", err, "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return nil, fmt.Errorf("parsing response: %w", err)
 	}
+
+	logger.Debug("request completed", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 
 	return &usage, nil
 }

--- a/pkg/openrouter/usage.go
+++ b/pkg/openrouter/usage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sort"
 	"time"
@@ -329,8 +330,12 @@ func fetchActivity(client *http.Client, auth *Auth) (*activityResponse, error) {
 }
 
 func doJSON(client *http.Client, auth *Auth, method, url string, target any) error {
+	logger := slog.With("provider", "openrouter", "method", method, "url", url)
+	started := time.Now()
+
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
+		logger.Error("build request failed", "error", err)
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+auth.APIKey)
@@ -338,22 +343,28 @@ func doJSON(client *http.Client, auth *Auth, method, url string, target any) err
 
 	resp, err := client.Do(req)
 	if err != nil {
+		logger.Warn("request failed", "error", err, "duration_ms", time.Since(started).Milliseconds())
 		return err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Warn("read response failed", "error", err, "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return fmt.Errorf("read response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return fmt.Errorf("OpenRouter API %s returned status %d: %s", url, resp.StatusCode, string(body))
 	}
 
 	if err := json.Unmarshal(body, target); err != nil {
+		logger.Warn("parse response failed", "error", err, "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return fmt.Errorf("parse response: %w", err)
 	}
+
+	logger.Debug("request completed", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- add global `slog` initialization with file-backed output so runtime logs do not interfere with the Bubble Tea TUI
- make logging configurable via `log.level` and `log.path`, with a sensible default under the local state directory
- log provider auth, refresh retries, and API request failures with structured fields for easier debugging