### PR TITLE
Add Claude provider with compact UI mode

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -108,7 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(tui.New(codexAuth, orAuth, claudeAuth, cfg.CodexUI, cfg.OpenRouterUI, AppVersion), tea.WithAltScreen())
+	p := tea.NewProgram(tui.New(codexAuth, orAuth, claudeAuth, cfg.CodexUI, cfg.ClaudeUI, cfg.OpenRouterUI, AppVersion), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		slog.Error("tui exited with error", "error", err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Log          LogConfig          `mapstructure:"log"`
 	Providers    ProvidersConfig    `mapstructure:"providers"`
 	CodexUI      CodexUIConfig      `mapstructure:"codex_ui"`
+	ClaudeUI     ClaudeUIConfig     `mapstructure:"claude_ui"`
 	OpenRouterUI OpenRouterUIConfig `mapstructure:"openrouter_ui"`
 }
 
@@ -32,7 +33,12 @@ type ProviderConfig struct {
 }
 
 type CodexUIConfig struct {
+	Compact    bool `mapstructure:"compact"`
 	CodeReview bool `mapstructure:"code_review"`
+}
+
+type ClaudeUIConfig struct {
+	Compact bool `mapstructure:"compact"`
 }
 
 type OpenRouterUIConfig struct {

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -11,7 +11,11 @@ providers:
     enabled: true
 
 codex_ui:
+  compact: false
   code_review: false
+
+claude_ui:
+  compact: false
 
 openrouter_ui:
   summary: true

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -34,18 +34,26 @@ func (m Model) claudeSection() string {
 
 	u := m.claudeUsage
 	bw := m.barWidth()
+	render := renderBar
+	if m.claudeUIConfig.Compact {
+		render = renderCompactBar
+	}
 
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Plan: %s | Tier: %s", u.SubscriptionType, u.RateLimitTier)))
 	b.WriteByte('\n')
-	b.WriteByte('\n')
+	if !m.claudeUIConfig.Compact {
+		b.WriteByte('\n')
+	}
 
 	if w := u.SessionLimit; w != nil {
 		resetInfo := ""
 		if !w.ResetAt.IsZero() {
 			resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
 		}
-		b.WriteString(renderBar("5h Limit", w.Utilization*100, bw, resetInfo))
-		b.WriteByte('\n')
+		b.WriteString(render("5h Limit", w.Utilization*100, bw, resetInfo))
+		if !m.claudeUIConfig.Compact {
+			b.WriteByte('\n')
+		}
 	}
 
 	if w := u.WeeklyLimit; w != nil {
@@ -53,10 +61,13 @@ func (m Model) claudeSection() string {
 		if !w.ResetAt.IsZero() {
 			resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
 		}
-		b.WriteString(renderBar("Weekly", w.Utilization*100, bw, resetInfo))
-		b.WriteByte('\n')
+		b.WriteString(render("Weekly  ", w.Utilization*100, bw, resetInfo))
+		if !m.claudeUIConfig.Compact {
+			b.WriteByte('\n')
+		}
 	}
 
+	b.WriteByte('\n')
 	return b.String()
 }
 

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -48,7 +48,11 @@ func (m Model) claudeSection() string {
 	if w := u.SessionLimit; w != nil {
 		resetInfo := ""
 		if !w.ResetAt.IsZero() {
-			resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
+			if m.claudeUIConfig.Compact {
+				resetInfo = timeUntil(w.ResetAt)
+			} else {
+				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
+			}
 		}
 		b.WriteString(render("5h Limit", w.Utilization*100, bw, resetInfo))
 		if !m.claudeUIConfig.Compact {
@@ -59,7 +63,11 @@ func (m Model) claudeSection() string {
 	if w := u.WeeklyLimit; w != nil {
 		resetInfo := ""
 		if !w.ResetAt.IsZero() {
-			resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
+			if m.claudeUIConfig.Compact {
+				resetInfo = timeUntil(w.ResetAt)
+			} else {
+				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
+			}
 		}
 		b.WriteString(render("Weekly  ", w.Utilization*100, bw, resetInfo))
 		if !m.claudeUIConfig.Compact {

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -34,6 +34,10 @@ func (m Model) codexSection() string {
 
 	u := m.codexUsage
 	bw := m.barWidth()
+	render := renderBar
+	if m.codexUIConfig.Compact {
+		render = renderCompactBar
+	}
 
 	credits := ""
 	if u.Credits.HasCredits {
@@ -45,30 +49,38 @@ func (m Model) codexSection() string {
 	}
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Plan: %s%s", u.PlanType, credits)))
 	b.WriteByte('\n')
-	b.WriteByte('\n')
+	if !m.codexUIConfig.Compact {
+		b.WriteByte('\n')
+	}
 
 	if w := u.RateLimit.PrimaryWindow; w != nil {
-		b.WriteString(renderBar("5h Limit", w.UsedPercent, bw,
+		b.WriteString(render("5h Limit", w.UsedPercent, bw,
 			fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("3:04 PM"), timeUntil(w.ResetTime())),
 		))
-		b.WriteByte('\n')
-	}
-	if w := u.RateLimit.SecondaryWindow; w != nil {
-		b.WriteString(renderBar("Weekly", w.UsedPercent, bw,
-			fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
-		))
-		b.WriteByte('\n')
-	}
-	if m.codexUIConfig.CodeReview {
-		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
-			b.WriteString(renderBar("Code Review", w.UsedPercent, bw,
-				fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
-			))
+		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
 	}
+	if w := u.RateLimit.SecondaryWindow; w != nil {
+		b.WriteString(render("Weekly  ", w.UsedPercent, bw,
+			fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
+		))
+		if !m.codexUIConfig.Compact {
+			b.WriteByte('\n')
+		}
+	}
+	if m.codexUIConfig.CodeReview {
+		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
+			b.WriteString(render("Code Review", w.UsedPercent, bw,
+				fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
+			))
+			if !m.codexUIConfig.Compact {
+				b.WriteByte('\n')
+			}
+		}
+	}
 
-	// b.WriteByte('\n')
+	b.WriteByte('\n')
 	return b.String()
 }
 

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -54,26 +54,32 @@ func (m Model) codexSection() string {
 	}
 
 	if w := u.RateLimit.PrimaryWindow; w != nil {
-		b.WriteString(render("5h Limit", w.UsedPercent, bw,
-			fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("3:04 PM"), timeUntil(w.ResetTime())),
-		))
+		resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("3:04 PM"), timeUntil(w.ResetTime()))
+		if m.codexUIConfig.Compact {
+			resetInfo = timeUntil(w.ResetTime())
+		}
+		b.WriteString(render("5h Limit", w.UsedPercent, bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
 	}
 	if w := u.RateLimit.SecondaryWindow; w != nil {
-		b.WriteString(render("Weekly  ", w.UsedPercent, bw,
-			fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
-		))
+		resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime()))
+		if m.codexUIConfig.Compact {
+			resetInfo = timeUntil(w.ResetTime())
+		}
+		b.WriteString(render("Weekly  ", w.UsedPercent, bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
 	}
 	if m.codexUIConfig.CodeReview {
 		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
-			b.WriteString(render("Code Review", w.UsedPercent, bw,
-				fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime())),
-			))
+			resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime()))
+			if m.codexUIConfig.Compact {
+				resetInfo = timeUntil(w.ResetTime())
+			}
+			b.WriteString(render("Code Review", w.UsedPercent, bw, resetInfo))
 			if !m.codexUIConfig.Compact {
 				b.WriteByte('\n')
 			}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -269,13 +269,13 @@ func renderBar(label string, usedPercent float64, barWidth int, resetInfo string
 	return b.String()
 }
 
+const compactResetWidth = 12 // fixed width for reset info, e.g. "in 164h 58m"
+
 func renderCompactBar(label string, usedPercent float64, barWidth int, resetInfo string) string {
 	used := math.Min(usedPercent, 100)
 
-	// Shrink bar to fit label, pct, and reset info on one line
-	// Layout: "  {label}{pct}  {bar}  {resetInfo}"
-	//          2 + labelWidth + 5(pct) + 2 + bar + 2 + len(resetInfo)
-	overhead := barPadding + len(resetInfo)
+	// Shrink bar to fit label, pct, and fixed-width reset info on one line
+	overhead := barPadding + compactResetWidth + 2
 	compactBarWidth := barWidth - overhead
 	if compactBarWidth < 10 {
 		compactBarWidth = 10
@@ -289,16 +289,14 @@ func renderCompactBar(label string, usedPercent float64, barWidth int, resetInfo
 	filled := barFilledStyle(c).Render(strings.Repeat(" ", filledCount))
 	empty := barEmptyStyle.Render(strings.Repeat(" ", emptyCount))
 
+	reset := fmt.Sprintf("%*s", compactResetWidth, resetInfo)
+
 	var b strings.Builder
-	reset := ""
-	if resetInfo != "" {
-		reset = "  " + dimStyle.Render(resetInfo)
-	}
-	b.WriteString(fmt.Sprintf("  %s%s  %s%s%s\n",
+	b.WriteString(fmt.Sprintf("  %s%s  %s%s  %s\n",
 		labelStyle.Render(label),
 		pctStyle(c).Render(fmt.Sprintf("%4.0f%%", used)),
 		filled, empty,
-		reset,
+		dimStyle.Render(reset),
 	))
 	return b.String()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -44,11 +44,12 @@ type claudeUsageMsg struct {
 type claudeRetryMsg struct{}
 
 type Model struct {
-	version       string
-	width         int
-	lastFetch     time.Time
-	codexUIConfig config.CodexUIConfig
-	orUIConfig    config.OpenRouterUIConfig
+	version        string
+	width          int
+	lastFetch      time.Time
+	codexUIConfig  config.CodexUIConfig
+	claudeUIConfig config.ClaudeUIConfig
+	orUIConfig     config.OpenRouterUIConfig
 
 	codexAuth    *codex.Auth
 	codexUsage   *codex.Usage
@@ -66,14 +67,15 @@ type Model struct {
 	claudeRetries int
 }
 
-func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth, codexUIConfig config.CodexUIConfig, orUIConfig config.OpenRouterUIConfig, version string) Model {
+func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth, codexUIConfig config.CodexUIConfig, claudeUIConfig config.ClaudeUIConfig, orUIConfig config.OpenRouterUIConfig, version string) Model {
 	return Model{
-		codexAuth:     codexAuth,
-		orAuth:        orAuth,
-		claudeAuth:    claudeAuth,
-		codexUIConfig: codexUIConfig,
-		orUIConfig:    orUIConfig,
-		version:       version,
+		codexAuth:      codexAuth,
+		orAuth:         orAuth,
+		claudeAuth:     claudeAuth,
+		codexUIConfig:  codexUIConfig,
+		claudeUIConfig: claudeUIConfig,
+		orUIConfig:     orUIConfig,
+		version:        version,
 	}
 }
 
@@ -264,6 +266,40 @@ func renderBar(label string, usedPercent float64, barWidth int, resetInfo string
 		pctStyle(c).Render(fmt.Sprintf("%4.0f%% free", remaining)),
 	))
 	b.WriteString("   " + dimStyle.Render(resetInfo) + "\n")
+	return b.String()
+}
+
+func renderCompactBar(label string, usedPercent float64, barWidth int, resetInfo string) string {
+	used := math.Min(usedPercent, 100)
+
+	// Shrink bar to fit label, pct, and reset info on one line
+	// Layout: "  {label}{pct}  {bar}  {resetInfo}"
+	//          2 + labelWidth + 5(pct) + 2 + bar + 2 + len(resetInfo)
+	overhead := barPadding + len(resetInfo)
+	compactBarWidth := barWidth - overhead
+	if compactBarWidth < 10 {
+		compactBarWidth = 10
+	}
+
+	filledCount := int(math.Round(used / 100 * float64(compactBarWidth)))
+	emptyCount := compactBarWidth - filledCount
+
+	c := usageColor(used)
+
+	filled := barFilledStyle(c).Render(strings.Repeat(" ", filledCount))
+	empty := barEmptyStyle.Render(strings.Repeat(" ", emptyCount))
+
+	var b strings.Builder
+	reset := ""
+	if resetInfo != "" {
+		reset = "  " + dimStyle.Render(resetInfo)
+	}
+	b.WriteString(fmt.Sprintf("  %s%s  %s%s%s\n",
+		labelStyle.Render(label),
+		pctStyle(c).Render(fmt.Sprintf("%4.0f%%", used)),
+		filled, empty,
+		reset,
+	))
 	return b.String()
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -2,7 +2,7 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
-const barPadding = 30 // space taken by "  Used: XXX%  " + " XXX% free"
+const barPadding = 12
 
 var (
 	green  = lipgloss.Color("2")


### PR DESCRIPTION
## Summary
- Add Claude provider that auto-reads OAuth credentials from `~/.claude/.credentials.json` (Claude Code)
- Fetch usage data by parsing rate limit headers (`5h-utilization`, `7d-utilization`) from a minimal Haiku API call
- Add `codex_ui.compact` and `claude_ui.compact` config flags for single-line usage bars
- Add `codex_ui.code_review` config to toggle code review bar (default off)
- Fix compact bar alignment so reset info fits on one line
- Render order: Claude, Codex, OpenRouter