### PR TITLE
load claude credentials from macOS keychain

### DIFF
--- a/pkg/claude/auth.go
+++ b/pkg/claude/auth.go
@@ -1,10 +1,13 @@
 package claude
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 type Auth struct {
@@ -20,6 +23,21 @@ type credentialsFile struct {
 }
 
 func LoadAuth() (*Auth, error) {
+	if runtime.GOOS == "darwin" {
+		auth, kcErr := loadAuthFromKeychain()
+		if kcErr == nil {
+			return auth, nil
+		}
+		auth, fileErr := loadAuthFromFile()
+		if fileErr == nil {
+			return auth, nil
+		}
+		return nil, fmt.Errorf("no Claude credentials found: keychain: %v; file: %v", kcErr, fileErr)
+	}
+	return loadAuthFromFile()
+}
+
+func loadAuthFromFile() (*Auth, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -28,12 +46,24 @@ func LoadAuth() (*Auth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading ~/.claude/.credentials.json: %w", err)
 	}
+	return parseCredentials(data, "~/.claude/.credentials.json")
+}
+
+func loadAuthFromKeychain() (*Auth, error) {
+	out, err := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials", "-w").Output()
+	if err != nil {
+		return nil, fmt.Errorf("reading claude keychain: %w", err)
+	}
+	return parseCredentials(bytes.TrimSpace(out), "claude keychain")
+}
+
+func parseCredentials(data []byte, source string) (*Auth, error) {
 	var creds credentialsFile
 	if err := json.Unmarshal(data, &creds); err != nil {
 		return nil, fmt.Errorf("parsing credentials: %w", err)
 	}
 	if creds.ClaudeAiOauth == nil || creds.ClaudeAiOauth.AccessToken == "" {
-		return nil, fmt.Errorf("no OAuth credentials found in ~/.claude/.credentials.json")
+		return nil, fmt.Errorf("no OAuth credentials found in %s", source)
 	}
 	return creds.ClaudeAiOauth, nil
 }


### PR DESCRIPTION
## Summary
- On darwin, `LoadAuth()` now reads from the macOS Keychain (service `Claude Code-credentials`) via `security find-generic-password`, falling back to `~/.claude/.credentials.json` if the keychain lookup fails.
- Linux behavior is unchanged — file-only, identical error messages.
- Fixes the Claude panel not appearing on macOS, where Claude Code stores OAuth credentials in Keychain rather than the credentials file.