### PR TITLE
Add release workflow using GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+version: 2
+
+project_name: tokentop
+
+builds:
+  - id: tokentop
+    main: ./cmd/tokentop
+    binary: tokentop
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.AppVersion={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+
+release:
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yml` producing static builds for `linux/darwin × amd64/arm64` with `main.AppVersion` injected via `-ldflags`, plus `tar.gz` archives and `checksums.txt`.
- Add `.github/workflows/release.yml` that triggers on `v*` tag pushes and runs `goreleaser/goreleaser-action@v6` with `contents: write`.
- Auto-flags pre-release tags (e.g. `-rc1`, `-beta`) via `prerelease: auto`; filters `docs:` / `test:` / `chore:` / merge commits from the generated changelog.