### PR TITLE
Show time-elapsed tick mark on usage bars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,9 +28,11 @@ providers:
 codex_ui:
   compact: false
   code_review: false
+  pace_tick: true
 
 claude_ui:
   compact: false
+  pace_tick: true
 
 openrouter_ui:
   summary: true
@@ -68,12 +70,14 @@ CLI flags can override the providers block for a single run — see [Keybindings
 |---------------|---------|-------------|
 | `compact`     | `false` | Render Codex section in a single-line-per-bar compact form. |
 | `code_review` | `false` | Show the separate code-review rate limit window. |
+| `pace_tick`   | `true`  | Split usage bars at the time-elapsed mark to show over/under-pace burn. |
 
 ### `claude_ui`
 
-| Key       | Default | Description |
-|-----------|---------|-------------|
-| `compact` | `false` | Render Claude section in compact form. |
+| Key         | Default | Description |
+|-------------|---------|-------------|
+| `compact`   | `false` | Render Claude section in compact form. |
+| `pace_tick` | `true`  | Split usage bars at the time-elapsed mark to show over/under-pace burn. |
 
 ### `openrouter_ui`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,12 @@ type ProviderConfig struct {
 type CodexUIConfig struct {
 	Compact    bool `mapstructure:"compact"`
 	CodeReview bool `mapstructure:"code_review"`
+	PaceTick   bool `mapstructure:"pace_tick"`
 }
 
 type ClaudeUIConfig struct {
-	Compact bool `mapstructure:"compact"`
+	Compact  bool `mapstructure:"compact"`
+	PaceTick bool `mapstructure:"pace_tick"`
 }
 
 type OpenRouterUIConfig struct {
@@ -64,6 +66,12 @@ func Load() (*Config, error) {
 	a.AutomaticEnv()
 
 	cfg := &Config{
+		CodexUI: CodexUIConfig{
+			PaceTick: true,
+		},
+		ClaudeUI: ClaudeUIConfig{
+			PaceTick: true,
+		},
 		OpenRouterUI: OpenRouterUIConfig{
 			Summary:    true,
 			DailySpend: true,

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -13,9 +13,11 @@ providers:
 codex_ui:
   compact: false
   code_review: false
+  pace_tick: true
 
 claude_ui:
   compact: false
+  pace_tick: true
 
 openrouter_ui:
   summary: true

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -17,7 +17,7 @@ const (
 
 func (m Model) claudeElapsedPercent(resetAt time.Time, window time.Duration) float64 {
 	if !m.claudeUIConfig.PaceTick {
-		return 0
+		return -1
 	}
 	return elapsedPercent(resetAt, window)
 }

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -15,6 +15,13 @@ const (
 	claudeWeeklyWindow  = 7 * 24 * time.Hour
 )
 
+func (m Model) claudeElapsedPercent(resetAt time.Time, window time.Duration) float64 {
+	if !m.claudeUIConfig.PaceTick {
+		return 0
+	}
+	return elapsedPercent(resetAt, window)
+}
+
 func (m Model) claudeSection() string {
 	var b strings.Builder
 	b.WriteString(sectionStyle.Render(" Claude"))
@@ -60,7 +67,7 @@ func (m Model) claudeSection() string {
 				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
 			}
 		}
-		b.WriteString(render("5h Limit", w.Utilization*100, elapsedPercent(w.ResetAt, claudeSessionWindow), bw, resetInfo))
+		b.WriteString(render("5h Limit", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeSessionWindow), bw, resetInfo))
 		if !m.claudeUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -75,7 +82,7 @@ func (m Model) claudeSection() string {
 				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
 			}
 		}
-		b.WriteString(render("Weekly  ", w.Utilization*100, elapsedPercent(w.ResetAt, claudeWeeklyWindow), bw, resetInfo))
+		b.WriteString(render("Weekly  ", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeWeeklyWindow), bw, resetInfo))
 		if !m.claudeUIConfig.Compact {
 			b.WriteByte('\n')
 		}

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -3,10 +3,16 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lwlee2608/tokentop/pkg/claude"
 
 	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	claudeSessionWindow = 5 * time.Hour
+	claudeWeeklyWindow  = 7 * 24 * time.Hour
 )
 
 func (m Model) claudeSection() string {
@@ -54,7 +60,7 @@ func (m Model) claudeSection() string {
 				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
 			}
 		}
-		b.WriteString(render("5h Limit", w.Utilization*100, bw, resetInfo))
+		b.WriteString(render("5h Limit", w.Utilization*100, elapsedPercent(w.ResetAt, claudeSessionWindow), bw, resetInfo))
 		if !m.claudeUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -69,7 +75,7 @@ func (m Model) claudeSection() string {
 				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
 			}
 		}
-		b.WriteString(render("Weekly  ", w.Utilization*100, bw, resetInfo))
+		b.WriteString(render("Weekly  ", w.Utilization*100, elapsedPercent(w.ResetAt, claudeWeeklyWindow), bw, resetInfo))
 		if !m.claudeUIConfig.Compact {
 			b.WriteByte('\n')
 		}

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -12,7 +12,7 @@ import (
 
 func (m Model) codexElapsedPercent(w *codex.UsageWindow) float64 {
 	if !m.codexUIConfig.PaceTick || w == nil || w.LimitWindowSeconds <= 0 {
-		return 0
+		return -1
 	}
 	return elapsedPercent(w.ResetTime(), time.Duration(w.LimitWindowSeconds)*time.Second)
 }

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -10,8 +10,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func codexElapsedPercent(w *codex.UsageWindow) float64 {
-	if w == nil || w.LimitWindowSeconds <= 0 {
+func (m Model) codexElapsedPercent(w *codex.UsageWindow) float64 {
+	if !m.codexUIConfig.PaceTick || w == nil || w.LimitWindowSeconds <= 0 {
 		return 0
 	}
 	return elapsedPercent(w.ResetTime(), time.Duration(w.LimitWindowSeconds)*time.Second)
@@ -66,7 +66,7 @@ func (m Model) codexSection() string {
 		if m.codexUIConfig.Compact {
 			resetInfo = timeUntil(w.ResetTime())
 		}
-		b.WriteString(render("5h Limit", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
+		b.WriteString(render("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -76,7 +76,7 @@ func (m Model) codexSection() string {
 		if m.codexUIConfig.Compact {
 			resetInfo = timeUntil(w.ResetTime())
 		}
-		b.WriteString(render("Weekly  ", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
+		b.WriteString(render("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -87,7 +87,7 @@ func (m Model) codexSection() string {
 			if m.codexUIConfig.Compact {
 				resetInfo = timeUntil(w.ResetTime())
 			}
-			b.WriteString(render("Code Review", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
+			b.WriteString(render("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
 			if !m.codexUIConfig.Compact {
 				b.WriteByte('\n')
 			}

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -3,11 +3,19 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lwlee2608/tokentop/pkg/codex"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+func codexElapsedPercent(w *codex.UsageWindow) float64 {
+	if w == nil || w.LimitWindowSeconds <= 0 {
+		return 0
+	}
+	return elapsedPercent(w.ResetTime(), time.Duration(w.LimitWindowSeconds)*time.Second)
+}
 
 func (m Model) codexSection() string {
 	var b strings.Builder
@@ -58,7 +66,7 @@ func (m Model) codexSection() string {
 		if m.codexUIConfig.Compact {
 			resetInfo = timeUntil(w.ResetTime())
 		}
-		b.WriteString(render("5h Limit", w.UsedPercent, bw, resetInfo))
+		b.WriteString(render("5h Limit", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -68,7 +76,7 @@ func (m Model) codexSection() string {
 		if m.codexUIConfig.Compact {
 			resetInfo = timeUntil(w.ResetTime())
 		}
-		b.WriteString(render("Weekly  ", w.UsedPercent, bw, resetInfo))
+		b.WriteString(render("Weekly  ", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
 		if !m.codexUIConfig.Compact {
 			b.WriteByte('\n')
 		}
@@ -79,7 +87,7 @@ func (m Model) codexSection() string {
 			if m.codexUIConfig.Compact {
 				resetInfo = timeUntil(w.ResetTime())
 			}
-			b.WriteString(render("Code Review", w.UsedPercent, bw, resetInfo))
+			b.WriteString(render("Code Review", w.UsedPercent, codexElapsedPercent(w), bw, resetInfo))
 			if !m.codexUIConfig.Compact {
 				b.WriteByte('\n')
 			}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -258,23 +258,51 @@ func (m Model) footer() string {
 	return dimStyle.Render(info) + "\n" + dimStyle.Render(strings.Repeat("─", m.width))
 }
 
-func renderBar(label string, usedPercent float64, barWidth int, resetInfo string) string {
+func tickIndex(elapsedPercent float64, barWidth int) int {
+	if elapsedPercent <= 0 || elapsedPercent >= 100 {
+		return -1
+	}
+	idx := int(math.Round(elapsedPercent/100*float64(barWidth))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= barWidth {
+		idx = barWidth - 1
+	}
+	return idx
+}
+
+func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
 	used := math.Min(usedPercent, 100)
 	remaining := 100 - used
 
 	filledCount := int(math.Round(used / 100 * float64(barWidth)))
-	emptyCount := barWidth - filledCount
-
 	c := usageColor(used)
+	tIdx := tickIndex(elapsedPercent, barWidth)
 
-	filled := barFilledStyle(c).Render(strings.Repeat(" ", filledCount))
-	empty := barEmptyStyle.Render(strings.Repeat(" ", emptyCount))
+	var bar strings.Builder
+	for i := 0; i < barWidth; i++ {
+		inFilled := i < filledCount
+		if i == tIdx {
+			if inFilled {
+				bar.WriteString(barTickStyle(c).Render("│"))
+			} else {
+				bar.WriteString(barTickStyle(gray).Render("│"))
+			}
+			continue
+		}
+		if inFilled {
+			bar.WriteString(barFilledStyle(c).Render(" "))
+		} else {
+			bar.WriteString(barEmptyStyle.Render(" "))
+		}
+	}
 
 	var b strings.Builder
 	b.WriteString("  " + labelStyle.Render(label) + "\n")
-	fmt.Fprintf(&b, "   Used:%s  %s%s  %s\n",
+	fmt.Fprintf(&b, "   Used:%s  %s  %s\n",
 		pctStyle(c).Render(fmt.Sprintf("%4.0f%%", used)),
-		filled, empty,
+		bar.String(),
 		pctStyle(c).Render(fmt.Sprintf("%4.0f%% free", remaining)),
 	)
 	b.WriteString("   " + dimStyle.Render(resetInfo) + "\n")
@@ -283,7 +311,7 @@ func renderBar(label string, usedPercent float64, barWidth int, resetInfo string
 
 const compactResetWidth = 8 // fixed width for reset info, e.g. "168h 59m"
 
-func renderCompactBar(label string, usedPercent float64, barWidth int, resetInfo string) string {
+func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
 	used := math.Min(usedPercent, 100)
 
 	// Shrink bar to fit label, pct, and fixed-width reset info on one line
@@ -292,20 +320,29 @@ func renderCompactBar(label string, usedPercent float64, barWidth int, resetInfo
 	compactBarWidth = max(compactBarWidth, 10)
 
 	filledCount := int(math.Round(used / 100 * float64(compactBarWidth)))
-	emptyCount := compactBarWidth - filledCount
-
 	c := usageColor(used)
+	tIdx := tickIndex(elapsedPercent, compactBarWidth)
 
-	filled := compactBarFilledStyle(c).Render(strings.Repeat("▄", filledCount))
-	empty := compactBarEmptyStyle.Render(strings.Repeat("▄", emptyCount))
+	var bar strings.Builder
+	for i := 0; i < compactBarWidth; i++ {
+		if i == tIdx {
+			bar.WriteString(tickStyle.Render("│"))
+			continue
+		}
+		if i < filledCount {
+			bar.WriteString(compactBarFilledStyle(c).Render("▄"))
+		} else {
+			bar.WriteString(compactBarEmptyStyle.Render("▄"))
+		}
+	}
 
 	reset := fmt.Sprintf("%*s", compactResetWidth, resetInfo)
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "  %s%s  %s%s  %s\n",
+	fmt.Fprintf(&b, "  %s%s  %s  %s\n",
 		labelStyle.Render(label),
 		pctStyle(c).Render(fmt.Sprintf("%4.0f%%", used)),
-		filled, empty,
+		bar.String(),
 		dimStyle.Render(reset),
 	)
 	return b.String()
@@ -328,6 +365,20 @@ func countdown() tea.Cmd {
 	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
 		return countdownMsg(t)
 	})
+}
+
+func elapsedPercent(resetAt time.Time, windowDuration time.Duration) float64 {
+	if resetAt.IsZero() || windowDuration <= 0 {
+		return 0
+	}
+	remaining := time.Until(resetAt)
+	if remaining <= 0 {
+		return 100
+	}
+	if remaining >= windowDuration {
+		return 0
+	}
+	return float64(windowDuration-remaining) / float64(windowDuration) * 100
 }
 
 func timeUntil(t time.Time) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -280,8 +280,10 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 	var bar strings.Builder
 	for i := 0; i < barWidth; i++ {
 		switch {
-		case i < filledCount:
+		case i < filledCount && i < eCount:
 			bar.WriteString(barFilledStyle(c).Render(" "))
+		case i < filledCount:
+			bar.WriteString(barOverPaceStyle(c).Render(" "))
 		case i < eCount:
 			bar.WriteString(barSlackStyle.Render(" "))
 		default:
@@ -317,8 +319,10 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	var bar strings.Builder
 	for i := 0; i < compactBarWidth; i++ {
 		switch {
-		case i < filledCount:
+		case i < filledCount && i < eCount:
 			bar.WriteString(compactBarFilledStyle(c).Render("▄"))
+		case i < filledCount:
+			bar.WriteString(compactBarOverPaceStyle(c).Render("▄"))
 		case i < eCount:
 			bar.WriteString(compactBarSlackStyle.Render("▄"))
 		default:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -284,11 +284,7 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 	for i := 0; i < barWidth; i++ {
 		inFilled := i < filledCount
 		if i == tIdx {
-			if inFilled {
-				bar.WriteString(barTickStyle(c).Render("▀"))
-			} else {
-				bar.WriteString(barTickStyle(gray).Render("▀"))
-			}
+			bar.WriteString(barTickStyle.Render(" "))
 			continue
 		}
 		if inFilled {
@@ -326,7 +322,7 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	var bar strings.Builder
 	for i := 0; i < compactBarWidth; i++ {
 		if i == tIdx {
-			bar.WriteString(tickStyle.Render("▀"))
+			bar.WriteString(tickStyle.Render("▄"))
 			continue
 		}
 		if i < filledCount {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -269,24 +269,62 @@ func elapsedCells(elapsedPercent float64, barWidth int) int {
 	return n
 }
 
+type barCellState uint8
+
+const (
+	barCellEmpty barCellState = iota
+	barCellSlack
+	barCellFilled
+	barCellOverPace
+)
+
+func buildBarCells(usedPercent, elapsedPercent float64, barWidth int) []barCellState {
+	if barWidth <= 0 {
+		return nil
+	}
+
+	used := math.Min(usedPercent, 100)
+	filledCount := int(math.Round(used / 100 * float64(barWidth)))
+
+	showElapsed := elapsedPercent >= 0
+	eCount := 0
+	if showElapsed {
+		eCount = elapsedCells(elapsedPercent, barWidth)
+	}
+
+	cells := make([]barCellState, barWidth)
+	for i := 0; i < barWidth; i++ {
+		switch {
+		case i < filledCount && (!showElapsed || i < eCount):
+			cells[i] = barCellFilled
+		case i < filledCount:
+			cells[i] = barCellOverPace
+		case showElapsed && i < eCount:
+			cells[i] = barCellSlack
+		default:
+			cells[i] = barCellEmpty
+		}
+	}
+	return cells
+}
+
 func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
 	used := math.Min(usedPercent, 100)
 	remaining := 100 - used
 
-	filledCount := int(math.Round(used / 100 * float64(barWidth)))
 	c := usageColor(used)
-	eCount := elapsedCells(elapsedPercent, barWidth)
+	cells := buildBarCells(usedPercent, elapsedPercent, barWidth)
 
 	var bar strings.Builder
-	for i := 0; i < barWidth; i++ {
-		switch {
-		case i < filledCount && (eCount == 0 || i < eCount):
+	for _, cell := range cells {
+		switch cell {
+		case barCellFilled:
 			bar.WriteString(barFilledStyle(c).Render(" "))
-		case i < filledCount:
+		case barCellOverPace:
 			bar.WriteString(barOverPaceStyle(c).Render(" "))
-		case i < eCount:
+		case barCellSlack:
 			bar.WriteString(barSlackStyle.Render(" "))
-		default:
+		case barCellEmpty:
 			bar.WriteString(barEmptyStyle.Render(" "))
 		}
 	}
@@ -312,20 +350,19 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	compactBarWidth := barWidth - overhead
 	compactBarWidth = max(compactBarWidth, 10)
 
-	filledCount := int(math.Round(used / 100 * float64(compactBarWidth)))
 	c := usageColor(used)
-	eCount := elapsedCells(elapsedPercent, compactBarWidth)
+	cells := buildBarCells(usedPercent, elapsedPercent, compactBarWidth)
 
 	var bar strings.Builder
-	for i := 0; i < compactBarWidth; i++ {
-		switch {
-		case i < filledCount && (eCount == 0 || i < eCount):
+	for _, cell := range cells {
+		switch cell {
+		case barCellFilled:
 			bar.WriteString(compactBarFilledStyle(c).Render("▄"))
-		case i < filledCount:
+		case barCellOverPace:
 			bar.WriteString(compactBarOverPaceStyle(c).Render("▄"))
-		case i < eCount:
+		case barCellSlack:
 			bar.WriteString(compactBarSlackStyle.Render("▄"))
-		default:
+		case barCellEmpty:
 			bar.WriteString(compactBarEmptyStyle.Render("▄"))
 		}
 	}
@@ -363,7 +400,7 @@ func countdown() tea.Cmd {
 
 func elapsedPercent(resetAt time.Time, windowDuration time.Duration) float64 {
 	if resetAt.IsZero() || windowDuration <= 0 {
-		return 0
+		return -1
 	}
 	remaining := time.Until(resetAt)
 	if remaining <= 0 {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -285,9 +285,9 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 		inFilled := i < filledCount
 		if i == tIdx {
 			if inFilled {
-				bar.WriteString(barTickStyle(c).Render("│"))
+				bar.WriteString(barTickStyle(c).Render("▀"))
 			} else {
-				bar.WriteString(barTickStyle(gray).Render("│"))
+				bar.WriteString(barTickStyle(gray).Render("▀"))
 			}
 			continue
 		}
@@ -326,7 +326,7 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	var bar strings.Builder
 	for i := 0; i < compactBarWidth; i++ {
 		if i == tIdx {
-			bar.WriteString(tickStyle.Render("│"))
+			bar.WriteString(tickStyle.Render("▀"))
 			continue
 		}
 		if i < filledCount {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -258,18 +258,15 @@ func (m Model) footer() string {
 	return dimStyle.Render(info) + "\n" + dimStyle.Render(strings.Repeat("─", m.width))
 }
 
-func tickIndex(elapsedPercent float64, barWidth int) int {
-	if elapsedPercent <= 0 || elapsedPercent >= 100 {
-		return -1
+func elapsedCells(elapsedPercent float64, barWidth int) int {
+	if elapsedPercent <= 0 {
+		return 0
 	}
-	idx := int(math.Round(elapsedPercent/100*float64(barWidth))) - 1
-	if idx < 0 {
-		idx = 0
+	n := int(math.Round(elapsedPercent / 100 * float64(barWidth)))
+	if n > barWidth {
+		n = barWidth
 	}
-	if idx >= barWidth {
-		idx = barWidth - 1
-	}
-	return idx
+	return n
 }
 
 func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
@@ -278,18 +275,16 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 
 	filledCount := int(math.Round(used / 100 * float64(barWidth)))
 	c := usageColor(used)
-	tIdx := tickIndex(elapsedPercent, barWidth)
+	eCount := elapsedCells(elapsedPercent, barWidth)
 
 	var bar strings.Builder
 	for i := 0; i < barWidth; i++ {
-		inFilled := i < filledCount
-		if i == tIdx {
-			bar.WriteString(barTickStyle.Render(" "))
-			continue
-		}
-		if inFilled {
+		switch {
+		case i < filledCount:
 			bar.WriteString(barFilledStyle(c).Render(" "))
-		} else {
+		case i < eCount:
+			bar.WriteString(barSlackStyle.Render(" "))
+		default:
 			bar.WriteString(barEmptyStyle.Render(" "))
 		}
 	}
@@ -317,17 +312,16 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 
 	filledCount := int(math.Round(used / 100 * float64(compactBarWidth)))
 	c := usageColor(used)
-	tIdx := tickIndex(elapsedPercent, compactBarWidth)
+	eCount := elapsedCells(elapsedPercent, compactBarWidth)
 
 	var bar strings.Builder
 	for i := 0; i < compactBarWidth; i++ {
-		if i == tIdx {
-			bar.WriteString(tickStyle.Render("▄"))
-			continue
-		}
-		if i < filledCount {
+		switch {
+		case i < filledCount:
 			bar.WriteString(compactBarFilledStyle(c).Render("▄"))
-		} else {
+		case i < eCount:
+			bar.WriteString(compactBarSlackStyle.Render("▄"))
+		default:
 			bar.WriteString(compactBarEmptyStyle.Render("▄"))
 		}
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -280,7 +280,7 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 	var bar strings.Builder
 	for i := 0; i < barWidth; i++ {
 		switch {
-		case i < filledCount && i < eCount:
+		case i < filledCount && (eCount == 0 || i < eCount):
 			bar.WriteString(barFilledStyle(c).Render(" "))
 		case i < filledCount:
 			bar.WriteString(barOverPaceStyle(c).Render(" "))
@@ -319,7 +319,7 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	var bar strings.Builder
 	for i := 0; i < compactBarWidth; i++ {
 		switch {
-		case i < filledCount && i < eCount:
+		case i < filledCount && (eCount == 0 || i < eCount):
 			bar.WriteString(compactBarFilledStyle(c).Render("▄"))
 		case i < filledCount:
 			bar.WriteString(compactBarOverPaceStyle(c).Render("▄"))

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import "testing"
+
+func TestBuildBarCellsStartOfWindowMarksUsageOverPace(t *testing.T) {
+	cells := buildBarCells(50, 0, 10)
+
+	for i := 0; i < 5; i++ {
+		if cells[i] != barCellOverPace {
+			t.Fatalf("cell %d = %v, want %v", i, cells[i], barCellOverPace)
+		}
+	}
+	for i := 5; i < len(cells); i++ {
+		if cells[i] != barCellEmpty {
+			t.Fatalf("cell %d = %v, want %v", i, cells[i], barCellEmpty)
+		}
+	}
+}
+
+func TestBuildBarCellsWithoutPaceDataUsesNormalFill(t *testing.T) {
+	cells := buildBarCells(50, -1, 10)
+
+	for i := 0; i < 5; i++ {
+		if cells[i] != barCellFilled {
+			t.Fatalf("cell %d = %v, want %v", i, cells[i], barCellFilled)
+		}
+	}
+	for i := 5; i < len(cells); i++ {
+		if cells[i] != barCellEmpty {
+			t.Fatalf("cell %d = %v, want %v", i, cells[i], barCellEmpty)
+		}
+	}
+}
+
+func TestOverPaceColorKeepsRedBarsDistinct(t *testing.T) {
+	if got := overPaceColor(red); got != brightRed {
+		t.Fatalf("overPaceColor(red) = %q, want %q", got, brightRed)
+	}
+}

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -42,7 +42,7 @@ func (m Model) orSection() string {
 	if u.Key.Limit > 0 {
 		b.WriteByte('\n')
 		usedPct := (u.Key.Limit - u.Key.LimitRemaining) / u.Key.Limit * 100
-		b.WriteString(renderBar("Credit Limit", usedPct, 0, bw,
+		b.WriteString(renderBar("Credit Limit", usedPct, -1, bw,
 			fmt.Sprintf("$%.4f remaining (resets %s)", u.Key.LimitRemaining, u.Key.LimitReset),
 		))
 		b.WriteByte('\n')

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -42,7 +42,7 @@ func (m Model) orSection() string {
 	if u.Key.Limit > 0 {
 		b.WriteByte('\n')
 		usedPct := (u.Key.Limit - u.Key.LimitRemaining) / u.Key.Limit * 100
-		b.WriteString(renderBar("Credit Limit", usedPct, bw,
+		b.WriteString(renderBar("Credit Limit", usedPct, 0, bw,
 			fmt.Sprintf("$%.4f remaining (resets %s)", u.Key.LimitRemaining, u.Key.LimitReset),
 		))
 		b.WriteByte('\n')

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -35,9 +35,7 @@ var compactBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
 var tickStyle = lipgloss.NewStyle().Foreground(white).Bold(true)
 
-func barTickStyle(bg lipgloss.Color) lipgloss.Style {
-	return lipgloss.NewStyle().Background(bg).Foreground(white).Bold(true)
-}
+var barTickStyle = lipgloss.NewStyle().Background(white)
 
 var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -33,9 +33,11 @@ func compactBarFilledStyle(c lipgloss.Color) lipgloss.Style {
 
 var compactBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
-var tickStyle = lipgloss.NewStyle().Foreground(white).Bold(true)
+var tickColor = lipgloss.Color("244")
 
-var barTickStyle = lipgloss.NewStyle().Background(white)
+var tickStyle = lipgloss.NewStyle().Foreground(tickColor).Bold(true)
+
+var barTickStyle = lipgloss.NewStyle().Background(tickColor)
 
 var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,6 +14,7 @@ var (
 	red    = lipgloss.Color("1")
 	white  = lipgloss.Color("15")
 	gray   = lipgloss.Color("237")
+	slack  = lipgloss.Color("244")
 
 	headerStyle  = lipgloss.NewStyle().Bold(true).Foreground(white)
 	sectionStyle = lipgloss.NewStyle().Bold(true).Foreground(white).Underline(true)
@@ -33,11 +34,9 @@ func compactBarFilledStyle(c lipgloss.Color) lipgloss.Style {
 
 var compactBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
-var tickColor = lipgloss.Color("244")
+var compactBarSlackStyle = lipgloss.NewStyle().Foreground(slack)
 
-var tickStyle = lipgloss.NewStyle().Foreground(tickColor).Bold(true)
-
-var barTickStyle = lipgloss.NewStyle().Background(tickColor)
+var barSlackStyle = lipgloss.NewStyle().Background(slack)
 
 var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -33,6 +33,12 @@ func compactBarFilledStyle(c lipgloss.Color) lipgloss.Style {
 
 var compactBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
+var tickStyle = lipgloss.NewStyle().Foreground(white).Bold(true)
+
+func barTickStyle(bg lipgloss.Color) lipgloss.Style {
+	return lipgloss.NewStyle().Background(bg).Foreground(white).Bold(true)
+}
+
 var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
 var modelBarColors = []lipgloss.Color{cyan, blue, green, yellow, orange, pink, red}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -38,6 +38,26 @@ var compactBarSlackStyle = lipgloss.NewStyle().Foreground(slack)
 
 var barSlackStyle = lipgloss.NewStyle().Background(slack)
 
+func compactBarOverPaceStyle(usage lipgloss.Color) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(overPaceColor(usage))
+}
+
+func barOverPaceStyle(usage lipgloss.Color) lipgloss.Style {
+	return lipgloss.NewStyle().Background(overPaceColor(usage))
+}
+
+// overPaceColor returns a color one step more alarming than the usage color.
+func overPaceColor(c lipgloss.Color) lipgloss.Color {
+	switch c {
+	case green:
+		return yellow
+	case yellow:
+		return red
+	default:
+		return red
+	}
+}
+
 var modelBarEmptyStyle = lipgloss.NewStyle().Foreground(gray)
 
 var modelBarColors = []lipgloss.Color{cyan, blue, green, yellow, orange, pink, red}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,16 +5,17 @@ import "github.com/charmbracelet/lipgloss"
 const barPadding = 12
 
 var (
-	green  = lipgloss.Color("2")
-	cyan   = lipgloss.Color("6")
-	blue   = lipgloss.Color("12")
-	orange = lipgloss.Color("208")
-	pink   = lipgloss.Color("205")
-	yellow = lipgloss.Color("3")
-	red    = lipgloss.Color("1")
-	white  = lipgloss.Color("15")
-	gray   = lipgloss.Color("237")
-	slack  = lipgloss.Color("244")
+	green     = lipgloss.Color("2")
+	cyan      = lipgloss.Color("6")
+	blue      = lipgloss.Color("12")
+	orange    = lipgloss.Color("208")
+	pink      = lipgloss.Color("205")
+	yellow    = lipgloss.Color("3")
+	red       = lipgloss.Color("1")
+	brightRed = lipgloss.Color("9")
+	white     = lipgloss.Color("15")
+	gray      = lipgloss.Color("237")
+	slack     = lipgloss.Color("244")
 
 	headerStyle  = lipgloss.NewStyle().Bold(true).Foreground(white)
 	sectionStyle = lipgloss.NewStyle().Bold(true).Foreground(white).Underline(true)
@@ -53,6 +54,8 @@ func overPaceColor(c lipgloss.Color) lipgloss.Color {
 		return yellow
 	case yellow:
 		return red
+	case red:
+		return brightRed
 	default:
 		return red
 	}


### PR DESCRIPTION
## Summary
- Overlay a vertical tick on each rate-limit bar at the time-elapsed position within the window.
- Visual pace indicator: filled bar left of tick = under pace; right of tick = burning faster than time.
- Applied to both full and compact bar renderers; Claude uses fixed 5h/7d windows, Codex uses `LimitWindowSeconds` from the API.