### PR TITLE
Drop compact UI flag; always render compact

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,12 +26,10 @@ providers:
     enabled: true
 
 codex_ui:
-  compact: false
   code_review: false
   pace_tick: true
 
 claude_ui:
-  compact: false
   pace_tick: true
 
 openrouter_ui:
@@ -69,7 +67,6 @@ CLI flags can override the providers block for a single run — see [Keybindings
 
 | Key           | Default | Description |
 |---------------|---------|-------------|
-| `compact`     | `false` | Render Codex section in a single-line-per-bar compact form. |
 | `code_review` | `false` | Show the separate code-review rate limit window. |
 | `pace_tick`   | `true`  | Split usage bars at the time-elapsed mark to show over/under-pace burn. |
 
@@ -77,7 +74,6 @@ CLI flags can override the providers block for a single run — see [Keybindings
 
 | Key         | Default | Description |
 |-------------|---------|-------------|
-| `compact`   | `false` | Render Claude section in compact form. |
 | `pace_tick` | `true`  | Split usage bars at the time-elapsed mark to show over/under-pace burn. |
 
 ### `openrouter_ui`
@@ -115,11 +111,3 @@ openrouter_ui:
   api_keys: false
 ```
 
-### Compact everything
-
-```yaml
-codex_ui:
-  compact: true
-claude_ui:
-  compact: true
-```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,14 +49,7 @@ Editing the entry's Access Control list directly is unreliable for unsigned bina
 
 ## The bars or percentages look wrong
 
-Resize the terminal and press `r`. Very narrow terminals are clamped to a minimum bar width but may still look cramped — enable compact mode:
-
-```yaml
-codex_ui:
-  compact: true
-claude_ui:
-  compact: true
-```
+Resize the terminal and press `r`. Very narrow terminals are clamped to a minimum bar width but may still look cramped.
 
 ## Logs
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,18 +35,15 @@ type ProviderConfig struct {
 }
 
 type CodexUIConfig struct {
-	Compact    bool `mapstructure:"compact"`
 	CodeReview bool `mapstructure:"code_review"`
 	PaceTick   bool `mapstructure:"pace_tick"`
 }
 
 type ClaudeUIConfig struct {
-	Compact  bool `mapstructure:"compact"`
 	PaceTick bool `mapstructure:"pace_tick"`
 }
 
 type OpenRouterUIConfig struct {
-	Compact    bool   `mapstructure:"compact"`
 	Summary    bool   `mapstructure:"summary"`
 	DailySpend bool   `mapstructure:"daily_spend"`
 	TopModels  bool   `mapstructure:"top_models"`
@@ -69,15 +66,12 @@ func Load() (*Config, error) {
 
 	cfg := &Config{
 		CodexUI: CodexUIConfig{
-			Compact:  true,
 			PaceTick: true,
 		},
 		ClaudeUI: ClaudeUIConfig{
-			Compact:  true,
 			PaceTick: true,
 		},
 		OpenRouterUI: OpenRouterUIConfig{
-			Compact:    true,
 			Summary:    true,
 			DailySpend: true,
 			TopModels:  true,

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -11,16 +11,13 @@ providers:
     enabled: true
 
 codex_ui:
-  compact: true
   code_review: false
   pace_tick: true
 
 claude_ui:
-  compact: true
   pace_tick: true
 
 openrouter_ui:
-  compact: true  # only applies when management key is not set
   summary: true
   daily_spend: true
   top_models: true

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -49,45 +49,24 @@ func (m Model) claudeSectionBody() string {
 
 	u := m.claudeUsage
 	bw := m.barWidth()
-	render := renderBar
-	if m.claudeUIConfig.Compact {
-		render = renderCompactBar
-	}
 
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Plan: %s | Tier: %s", u.SubscriptionType, u.RateLimitTier)))
 	b.WriteByte('\n')
-	if !m.claudeUIConfig.Compact {
-		b.WriteByte('\n')
-	}
 
 	if w := u.SessionLimit; w != nil {
 		resetInfo := ""
 		if !w.ResetAt.IsZero() {
-			if m.claudeUIConfig.Compact {
-				resetInfo = timeUntil(w.ResetAt)
-			} else {
-				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("3:04 PM"), timeUntil(w.ResetAt))
-			}
+			resetInfo = timeUntil(w.ResetAt)
 		}
-		b.WriteString(render("5h Limit", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeSessionWindow), bw, resetInfo))
-		if !m.claudeUIConfig.Compact {
-			b.WriteByte('\n')
-		}
+		b.WriteString(renderCompactBar("5h Limit", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeSessionWindow), bw, resetInfo))
 	}
 
 	if w := u.WeeklyLimit; w != nil {
 		resetInfo := ""
 		if !w.ResetAt.IsZero() {
-			if m.claudeUIConfig.Compact {
-				resetInfo = timeUntil(w.ResetAt)
-			} else {
-				resetInfo = fmt.Sprintf("resets %s (%s)", w.ResetAt.Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetAt))
-			}
+			resetInfo = timeUntil(w.ResetAt)
 		}
-		b.WriteString(render("Weekly  ", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeWeeklyWindow), bw, resetInfo))
-		if !m.claudeUIConfig.Compact {
-			b.WriteByte('\n')
-		}
+		b.WriteString(renderCompactBar("Weekly  ", w.Utilization*100, m.claudeElapsedPercent(w.ResetAt, claudeWeeklyWindow), bw, resetInfo))
 	}
 
 	b.WriteByte('\n')

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -44,10 +44,6 @@ func (m Model) codexSectionBody() string {
 
 	u := m.codexUsage
 	bw := m.barWidth()
-	render := renderBar
-	if m.codexUIConfig.Compact {
-		render = renderCompactBar
-	}
 
 	credits := ""
 	if u.Credits.HasCredits {
@@ -59,40 +55,16 @@ func (m Model) codexSectionBody() string {
 	}
 	b.WriteString(dimStyle.Render(fmt.Sprintf("  Plan: %s%s", u.PlanType, credits)))
 	b.WriteByte('\n')
-	if !m.codexUIConfig.Compact {
-		b.WriteByte('\n')
-	}
 
 	if w := u.RateLimit.PrimaryWindow; w != nil {
-		resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("3:04 PM"), timeUntil(w.ResetTime()))
-		if m.codexUIConfig.Compact {
-			resetInfo = timeUntil(w.ResetTime())
-		}
-		b.WriteString(render("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
-		if !m.codexUIConfig.Compact {
-			b.WriteByte('\n')
-		}
+		b.WriteString(renderCompactBar("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
 	}
 	if w := u.RateLimit.SecondaryWindow; w != nil {
-		resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime()))
-		if m.codexUIConfig.Compact {
-			resetInfo = timeUntil(w.ResetTime())
-		}
-		b.WriteString(render("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
-		if !m.codexUIConfig.Compact {
-			b.WriteByte('\n')
-		}
+		b.WriteString(renderCompactBar("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
 	}
 	if m.codexUIConfig.CodeReview {
 		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
-			resetInfo := fmt.Sprintf("resets %s (%s)", w.ResetTime().Local().Format("Mon Jan 2 3:04 PM"), timeUntil(w.ResetTime()))
-			if m.codexUIConfig.Compact {
-				resetInfo = timeUntil(w.ResetTime())
-			}
-			b.WriteString(render("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, resetInfo))
-			if !m.codexUIConfig.Compact {
-				b.WriteByte('\n')
-			}
+			b.WriteString(renderCompactBar("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
 		}
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -38,7 +38,6 @@ func TestCodexSectionRenderSnapshot(t *testing.T) {
 	m := Model{
 		width: 85,
 		codexUIConfig: config.CodexUIConfig{
-			Compact:    true,
 			CodeReview: false,
 			PaceTick:   true,
 		},
@@ -92,7 +91,6 @@ func TestClaudeSectionRenderSnapshot(t *testing.T) {
 	m := Model{
 		width: 85,
 		claudeUIConfig: config.ClaudeUIConfig{
-			Compact:  true,
 			PaceTick: true,
 		},
 		claudeUsage: &claude.Usage{
@@ -177,9 +175,7 @@ func TestOpenRouterCompactDailyKeySnapshot(t *testing.T) {
 
 	m := Model{
 		width: 85,
-		orUIConfig: config.OpenRouterUIConfig{
-			Compact: true,
-		},
+		orUIConfig: config.OpenRouterUIConfig{},
 		orAuth: &openrouter.Auth{
 			APIKey: "sk-or-v1-771xxxxxxxa29",
 		},

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -195,7 +195,7 @@ func (m Model) orSectionBody() string {
 		b.WriteString(header)
 	}
 
-	compactKey := m.orUIConfig.Compact && !u.Key.IsManagementKey
+	compactKey := !u.Key.IsManagementKey
 	periodLabel, hasPeriod := parseLimitResetPeriod(u.Key.LimitReset)
 	barCoversPeriod := false
 	if u.Key.Limit > 0 {


### PR DESCRIPTION
## Summary
- Remove `compact` field from `codex_ui`, `claude_ui`, and `openrouter_ui` config; compact rendering is now the only mode.
- Simplify `codex_view.go` and `claude_view.go` to always call `renderCompactBar`.
- In `openrouter_view.go`, `compactKey` now means "non-management key" (management-key path keeps the full `renderBar`).
- Update default config, docs, and snapshot tests to drop the flag.