### PR TITLE
Fix wide-rune clipping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/lwlee2608/adder v0.3.2
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/muesli/termenv v0.16.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,7 +23,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -174,7 +174,7 @@ func TestOpenRouterCompactDailyKeySnapshot(t *testing.T) {
 	forceTrueColorProfile(t)
 
 	m := Model{
-		width: 85,
+		width:      85,
 		orUIConfig: config.OpenRouterUIConfig{},
 		orAuth: &openrouter.Auth{
 			APIKey: "sk-or-v1-771xxxxxxxa29",
@@ -205,6 +205,12 @@ func TestOpenRouterCompactDailyKeySnapshot(t *testing.T) {
 	want, err := os.ReadFile(goldenPath)
 	require.NoError(t, err, "read golden")
 	assert.Equal(t, string(want), got, "openrouter compact section mismatch")
+}
+
+func TestClipLineKeepsWideRunesWithinMaxWidth(t *testing.T) {
+	got := clipLine("Status: 警告 warning", 10)
+
+	assert.LessOrEqual(t, lipgloss.Width(got), 10)
 }
 
 func TestBuildBarCellsStartOfWindowMarksUsageOverPace(t *testing.T) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,6 +5,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 const barPadding = 12
@@ -118,14 +119,14 @@ func clipLine(line string, maxW int) string {
 			i = j
 			continue
 		}
-		if visible >= maxW {
+		r, size := utf8.DecodeRuneInString(line[i:])
+		w := runewidth.RuneWidth(r)
+		if visible+w > maxW {
 			break
 		}
-		r, size := utf8.DecodeRuneInString(line[i:])
-		_ = r
 		b.WriteString(line[i : i+size])
 		i += size
-		visible++
+		visible += w
 	}
 	b.WriteString("\x1b[0m")
 	return b.String()


### PR DESCRIPTION
## Summary
- Count terminal cell width when clipping section lines so CJK and other wide runes do not overflow borders
- Add a regression test that verifies clipped wide-rune content stays within the maximum width