### PR TITLE
Tighten provider and TUI internals

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -91,8 +91,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Warning: openrouter: %v\n", err)
 		} else {
 			orAuth = auth
-			masked, _ := adder.PrettyJSON(orAuth)
-			slog.Info("openrouter provider enabled", "auth", masked)
+			slog.Info("openrouter provider enabled")
+			if slog.Default().Enabled(nil, slog.LevelDebug) {
+				if masked, err := adder.PrettyJSON(orAuth); err == nil {
+					slog.Debug("openrouter auth", "auth", masked)
+				}
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"bytes"
 	_ "embed"
+	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,10 +59,13 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
+	configDir := filepath.Join(home, ".config", "tokentop")
+	configPath := filepath.Join(configDir, "config.yaml")
+
 	a := adder.New()
 	a.SetConfigName("config")
 	a.SetConfigType("yaml")
-	a.AddConfigPath(filepath.Join(home, ".config", "tokentop"))
+	a.AddConfigPath(configDir)
 	a.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	a.AutomaticEnv()
 
@@ -80,23 +85,20 @@ func Load() (*Config, error) {
 		},
 	}
 
-	if err := a.ReadInConfig(); err != nil {
-		if strings.HasPrefix(err.Error(), "config file not found") {
-			writeDefaultConfig(filepath.Join(home, ".config", "tokentop", "config.yaml"))
-			// Retry after writing the default config
-			if err := a.ReadInConfig(); err != nil {
-				return cfg, nil
-			}
-		} else {
-			return nil, err
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		if werr := writeDefaultConfig(configPath); werr != nil {
+			slog.Warn("could not write default config, continuing with built-in defaults", "path", configPath, "error", werr)
+			return cfg, nil
 		}
 	}
 
+	if err := a.ReadInConfig(); err != nil {
+		return nil, err
+	}
 	if err := a.Unmarshal(cfg); err != nil {
 		return nil, err
 	}
 
-	configPath := filepath.Join(home, ".config", "tokentop", "config.yaml")
 	if backfillDefaults(configPath) {
 		if err := a.ReadInConfig(); err != nil {
 			return nil, err
@@ -112,11 +114,11 @@ func Load() (*Config, error) {
 //go:embed default_config.yaml
 var defaultConfigYAML []byte
 
-func writeDefaultConfig(path string) {
+func writeDefaultConfig(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return
+		return err
 	}
-	_ = os.WriteFile(path, defaultConfigYAML, 0644)
+	return os.WriteFile(path, defaultConfigYAML, 0644)
 }
 
 // backfillDefaults reads the existing config file and the embedded default,

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -73,9 +73,9 @@ func (m Model) claudeSectionBody() string {
 	return b.String()
 }
 
-func fetchClaudeUsage(auth *claude.Auth) tea.Cmd {
+func fetchClaudeUsage(auth *claude.Auth, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		usage, err := claude.FetchUsage(auth)
-		return claudeUsageMsg{usage: usage, err: err}
+		return claudeUsageMsg{usage: usage, err: err, gen: gen}
 	}
 }

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -72,9 +72,9 @@ func (m Model) codexSectionBody() string {
 	return b.String()
 }
 
-func fetchCodexUsage(auth *codex.Auth) tea.Cmd {
+func fetchCodexUsage(auth *codex.Auth, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		usage, err := codex.FetchUsage(auth)
-		return codexUsageMsg{usage: usage, err: err}
+		return codexUsageMsg{usage: usage, err: err, gen: gen}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,29 +26,33 @@ type countdownMsg time.Time
 type codexUsageMsg struct {
 	usage *codex.Usage
 	err   error
+	gen   uint64
 }
 
-type codexRetryMsg struct{}
+type codexRetryMsg struct{ gen uint64 }
 
 type orUsageMsg struct {
 	usage *openrouter.Usage
 	err   error
+	gen   uint64
 }
 
-type orRetryMsg struct{}
+type orRetryMsg struct{ gen uint64 }
 
 type claudeUsageMsg struct {
 	usage *claude.Usage
 	err   error
+	gen   uint64
 }
 
-type claudeRetryMsg struct{}
+type claudeRetryMsg struct{ gen uint64 }
 
 type Model struct {
 	version        string
 	width          int
 	lastFetch      time.Time
 	nextRefresh    time.Time
+	gen            uint64
 	codexUIConfig  config.CodexUIConfig
 	claudeUIConfig config.ClaudeUIConfig
 	orUIConfig     config.OpenRouterUIConfig
@@ -87,13 +91,13 @@ func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth
 func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{tick(), countdown()}
 	if m.codexAuth != nil {
-		cmds = append(cmds, fetchCodexUsage(m.codexAuth))
+		cmds = append(cmds, fetchCodexUsage(m.codexAuth, m.gen))
 	}
 	if m.orAuth != nil {
-		cmds = append(cmds, fetchORUsage(m.orAuth))
+		cmds = append(cmds, fetchORUsage(m.orAuth, m.gen))
 	}
 	if m.claudeAuth != nil {
-		cmds = append(cmds, fetchClaudeUsage(m.claudeAuth))
+		cmds = append(cmds, fetchClaudeUsage(m.claudeAuth, m.gen))
 	}
 	return tea.Batch(cmds...)
 }
@@ -104,13 +108,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 
 	case tea.KeyMsg:
-		if msg.String() == "q" || msg.String() == "ctrl+c" {
+		key := msg.String()
+		switch key {
+		case "q", "ctrl+c":
 			return m, tea.Quit
-		}
-		if msg.String() == "r" {
+		case "r":
 			return m.refresh()
-		}
-		if msg.String() == "m" {
+		case "m":
 			m.orMetric = m.orMetric.next()
 			return m, nil
 		}
@@ -122,24 +126,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.refresh()
 
 	case codexRetryMsg:
-		return m, fetchCodexUsage(m.codexAuth)
+		if msg.gen != m.gen {
+			return m, nil
+		}
+		return m, fetchCodexUsage(m.codexAuth, m.gen)
 
 	case orRetryMsg:
-		return m, fetchORUsage(m.orAuth)
+		if msg.gen != m.gen {
+			return m, nil
+		}
+		return m, fetchORUsage(m.orAuth, m.gen)
 
 	case claudeRetryMsg:
-		return m, fetchClaudeUsage(m.claudeAuth)
+		if msg.gen != m.gen {
+			return m, nil
+		}
+		return m, fetchClaudeUsage(m.claudeAuth, m.gen)
 
 	case codexUsageMsg:
+		if msg.gen != m.gen {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.codexErr = msg.err.Error()
-			slog.Warn("codex usage refresh failed", "error", msg.err, "retry", m.codexRetries, "max_retries", maxRetries)
-			if m.codexRetries < maxRetries {
-				m.codexRetries++
-				slog.Debug("scheduling codex usage retry", "retry", m.codexRetries, "delay", retryDelay.String())
-				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return codexRetryMsg{} })
+			if cmd := m.scheduleRetry("codex", &m.codexRetries, msg.err, func(g uint64) tea.Msg { return codexRetryMsg{gen: g} }); cmd != nil {
+				return m, cmd
 			}
-			slog.Error("codex usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
 		} else {
 			m.codexUsage = msg.usage
 			m.codexErr = ""
@@ -149,15 +161,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case orUsageMsg:
+		if msg.gen != m.gen {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.orErr = msg.err.Error()
-			slog.Warn("openrouter usage refresh failed", "error", msg.err, "retry", m.orRetries, "max_retries", maxRetries)
-			if m.orRetries < maxRetries {
-				m.orRetries++
-				slog.Debug("scheduling openrouter usage retry", "retry", m.orRetries, "delay", retryDelay.String())
-				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return orRetryMsg{} })
+			if cmd := m.scheduleRetry("openrouter", &m.orRetries, msg.err, func(g uint64) tea.Msg { return orRetryMsg{gen: g} }); cmd != nil {
+				return m, cmd
 			}
-			slog.Error("openrouter usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
 		} else {
 			if m.orUsage == nil {
 				keyType := "standard"
@@ -176,15 +187,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case claudeUsageMsg:
+		if msg.gen != m.gen {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.claudeErr = msg.err.Error()
-			slog.Warn("claude usage refresh failed", "error", msg.err, "retry", m.claudeRetries, "max_retries", maxRetries)
-			if m.claudeRetries < maxRetries {
-				m.claudeRetries++
-				slog.Debug("scheduling claude usage retry", "retry", m.claudeRetries, "delay", retryDelay.String())
-				return m, tea.Tick(retryDelay, func(time.Time) tea.Msg { return claudeRetryMsg{} })
+			if cmd := m.scheduleRetry("claude", &m.claudeRetries, msg.err, func(g uint64) tea.Msg { return claudeRetryMsg{gen: g} }); cmd != nil {
+				return m, cmd
 			}
-			slog.Error("claude usage refresh exhausted retries", "error", msg.err, "max_retries", maxRetries)
 		} else {
 			m.claudeUsage = msg.usage
 			m.claudeErr = ""
@@ -196,21 +206,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// scheduleRetry handles the common retry-with-backoff bookkeeping. Returns a
+// tea.Cmd to fire the retry, or nil when retries are exhausted.
+func (m Model) scheduleRetry(provider string, retries *int, err error, mkMsg func(gen uint64) tea.Msg) tea.Cmd {
+	slog.Warn(provider+" usage refresh failed", "error", err, "retry", *retries, "max_retries", maxRetries)
+	if *retries >= maxRetries {
+		slog.Error(provider+" usage refresh exhausted retries", "error", err, "max_retries", maxRetries)
+		return nil
+	}
+	*retries++
+	slog.Debug("scheduling "+provider+" usage retry", "retry", *retries, "delay", retryDelay.String())
+	gen := m.gen
+	return tea.Tick(retryDelay, func(time.Time) tea.Msg { return mkMsg(gen) })
+}
+
 func (m Model) refresh() (tea.Model, tea.Cmd) {
 	m.nextRefresh = time.Now().Add(refreshInterval)
+	m.gen++
 	m.codexRetries = 0
 	m.orRetries = 0
 	m.claudeRetries = 0
-	slog.Debug("starting usage refresh")
+	slog.Debug("starting usage refresh", "gen", m.gen)
 	var cmds []tea.Cmd
 	if m.codexAuth != nil {
-		cmds = append(cmds, fetchCodexUsage(m.codexAuth))
+		cmds = append(cmds, fetchCodexUsage(m.codexAuth, m.gen))
 	}
 	if m.orAuth != nil {
-		cmds = append(cmds, fetchORUsage(m.orAuth))
+		cmds = append(cmds, fetchORUsage(m.orAuth, m.gen))
 	}
 	if m.claudeAuth != nil {
-		cmds = append(cmds, fetchClaudeUsage(m.claudeAuth))
+		cmds = append(cmds, fetchClaudeUsage(m.claudeAuth, m.gen))
 	}
 	cmds = append(cmds, tick())
 	return m, tea.Batch(cmds...)
@@ -379,10 +404,10 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 	return b.String()
 }
 
-func fetchORUsage(auth *openrouter.Auth) tea.Cmd {
+func fetchORUsage(auth *openrouter.Auth, gen uint64) tea.Cmd {
 	return func() tea.Msg {
 		usage, err := openrouter.FetchUsage(auth)
-		return orUsageMsg{usage: usage, err: err}
+		return orUsageMsg{usage: usage, err: err, gen: gen}
 	}
 }
 

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lwlee2608/tokentop/pkg/openrouter"
+	"github.com/mattn/go-runewidth"
 )
 
 const (
@@ -519,15 +520,15 @@ func topNModels(modelSpend map[string]float64, n int) []string {
 	for m, s := range modelSpend {
 		all = append(all, ms{m, s})
 	}
-	for i := 0; i < len(all); i++ {
-		for j := i + 1; j < len(all); j++ {
-			if all[j].spend > all[i].spend {
-				all[i], all[j] = all[j], all[i]
-			}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].spend != all[j].spend {
+			return all[i].spend > all[j].spend
 		}
-	}
-	result := make([]string, 0, int(math.Min(float64(n), float64(len(all)))))
-	for i := 0; i < len(all) && i < n; i++ {
+		return all[i].model < all[j].model
+	})
+	limit := min(n, len(all))
+	result := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
 		result = append(result, all[i].model)
 	}
 	return result
@@ -648,8 +649,8 @@ func formatTokens(n float64) string {
 }
 
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	if runewidth.StringWidth(s) <= max {
 		return s
 	}
-	return s[:max-1] + "…"
+	return runewidth.Truncate(s, max, "…")
 }

--- a/pkg/claude/usage.go
+++ b/pkg/claude/usage.go
@@ -47,12 +47,13 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds(), "body", string(body))
+		return nil, fmt.Errorf("Anthropic API returned status %d: %s", resp.StatusCode, string(body))
 	}
+	io.Copy(io.Discard, resp.Body)
 
 	usage := &Usage{
 		SubscriptionType: auth.SubscriptionType,
@@ -86,10 +87,11 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 }
 
 func parseRateWindow(utilization, status, resetEpoch string) *RateWindow {
-	w := &RateWindow{Status: status}
-	if v, err := strconv.ParseFloat(utilization, 64); err == nil {
-		w.Utilization = v
+	v, err := strconv.ParseFloat(utilization, 64)
+	if err != nil {
+		return nil
 	}
+	w := &RateWindow{Status: status, Utilization: v}
 	if v, err := strconv.ParseInt(resetEpoch, 10, 64); err == nil && v > 0 {
 		w.ResetAt = time.Unix(v, 0)
 	}

--- a/pkg/codex/usage.go
+++ b/pkg/codex/usage.go
@@ -37,13 +37,6 @@ func (w *UsageWindow) ResetTime() time.Time {
 	return time.Unix(w.ResetAt, 0)
 }
 
-func (w *UsageWindow) WindowMinutes() int {
-	if w == nil {
-		return 0
-	}
-	return w.LimitWindowSeconds / 60
-}
-
 type UsageCredits struct {
 	HasCredits bool    `json:"has_credits"`
 	Unlimited  bool    `json:"unlimited"`
@@ -70,15 +63,15 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Warn("read response failed", "error", err, "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds())
 		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds(), "body", string(body))
+		return nil, fmt.Errorf("Codex API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var usage Usage

--- a/pkg/openrouter/usage.go
+++ b/pkg/openrouter/usage.go
@@ -263,17 +263,18 @@ func buildActivity(items []activityItem) *Activity {
 }
 
 func buildDailyActivity(items []activityItem) *DailyActivity {
-	type key struct{ date, model string }
-	agg := make(map[key]*ModelUsage)
-	dates := make(map[string]bool)
+	byDate := make(map[string]map[string]*ModelUsage)
 
 	for _, item := range items {
-		dates[item.Date] = true
-		k := key{item.Date, item.Model}
-		m := agg[k]
+		models := byDate[item.Date]
+		if models == nil {
+			models = make(map[string]*ModelUsage)
+			byDate[item.Date] = models
+		}
+		m := models[item.Model]
 		if m == nil {
 			m = &ModelUsage{Model: item.Model}
-			agg[k] = m
+			models[item.Model] = m
 		}
 		m.Spend += item.Usage
 		m.Requests += item.Requests
@@ -282,20 +283,19 @@ func buildDailyActivity(items []activityItem) *DailyActivity {
 		m.ReasoningTokens += item.ReasoningTokens
 	}
 
-	sortedDates := make([]string, 0, len(dates))
-	for d := range dates {
+	sortedDates := make([]string, 0, len(byDate))
+	for d := range byDate {
 		sortedDates = append(sortedDates, d)
 	}
 	sort.Strings(sortedDates)
 
-	daily := &DailyActivity{}
+	daily := &DailyActivity{Days: make([]DailyUsage, 0, len(sortedDates))}
 	for _, date := range sortedDates {
-		day := DailyUsage{Date: date}
-		for k, m := range agg {
-			if k.date == date {
-				day.Models = append(day.Models, *m)
-				day.Total += m.Spend
-			}
+		models := byDate[date]
+		day := DailyUsage{Date: date, Models: make([]ModelUsage, 0, len(models))}
+		for _, m := range models {
+			day.Models = append(day.Models, *m)
+			day.Total += m.Spend
 		}
 		sort.Slice(day.Models, func(i, j int) bool {
 			return day.Models[i].Spend > day.Models[j].Spend


### PR DESCRIPTION
## Summary
- Fix retry race: `refresh()` now increments a generation counter; in-flight retry/usage messages drop if stale, preventing duplicate fetches when `r` is pressed or a tick fires while a retry is pending
- Include response body in Claude/Codex API non-200 errors instead of returning a bare status code
- `parseRateWindow` returns `nil` on parse failure (was indistinguishable from real 0% utilization)
- Replace fragile `strings.HasPrefix` error matching in `config.Load` with `os.Stat` + `errors.Is`; surface previously swallowed write/retry errors
- Optimize `buildDailyActivity` from O(days×entries) to a single pass
- Replace hand-rolled bubble sort in `topNModels` with `sort.Slice`
- Make `truncate` rune-aware via `runewidth.Truncate`
- Move openrouter auth pretty-print log under debug guard
- Extract `scheduleRetry` helper to dedupe per-provider retry bookkeeping; remove dead `UsageWindow.WindowMinutes`