### PR TITLE
Show login hint when Claude credentials are missing or invalid

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -106,19 +106,20 @@ func main() {
 		if err != nil {
 			slog.Warn("claude auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: claude: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Hint: run `claude /login` to sign in\n")
 		} else {
 			claudeAuth = auth
 			slog.Info("claude provider enabled")
 		}
 	}
 
-	if codexAuth == nil && orAuth == nil && claudeAuth == nil {
+	if codexAuth == nil && orAuth == nil && claudeAuth == nil && !cfg.Providers.Anthropic.Enabled {
 		slog.Error("no providers available")
 		fmt.Fprintf(os.Stderr, "Error: no providers available\n")
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(tui.New(codexAuth, orAuth, claudeAuth, cfg.CodexUI, cfg.ClaudeUI, cfg.OpenRouterUI, AppVersion), tea.WithAltScreen())
+	p := tea.NewProgram(tui.New(codexAuth, orAuth, claudeAuth, cfg.Providers.Anthropic.Enabled, cfg.CodexUI, cfg.ClaudeUI, cfg.OpenRouterUI, AppVersion), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		slog.Error("tui exited with error", "error", err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -119,7 +119,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(tui.New(codexAuth, orAuth, claudeAuth, cfg.Providers.Anthropic.Enabled, cfg.CodexUI, cfg.ClaudeUI, cfg.OpenRouterUI, AppVersion), tea.WithAltScreen())
+	p := tea.NewProgram(tui.New(
+		tui.CodexProvider{Auth: codexAuth, UI: cfg.CodexUI},
+		tui.OpenRouterProvider{Auth: orAuth, UI: cfg.OpenRouterUI},
+		tui.ClaudeProvider{Auth: claudeAuth, Enabled: cfg.Providers.Anthropic.Enabled, UI: cfg.ClaudeUI},
+		AppVersion,
+	), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		slog.Error("tui exited with error", "error", err)
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -106,7 +106,7 @@ func main() {
 		if err != nil {
 			slog.Warn("claude auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: claude: %v\n", err)
-			fmt.Fprintf(os.Stderr, "Hint: run `claude /login` to sign in\n")
+			fmt.Fprintln(os.Stderr, "Hint:", claude.LoginHint)
 		} else {
 			claudeAuth = auth
 			slog.Info("claude provider enabled")

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -13,6 +13,7 @@ import (
 const (
 	claudeSessionWindow = 5 * time.Hour
 	claudeWeeklyWindow  = 7 * 24 * time.Hour
+	claudeLoginHint     = "  Hint: run `claude /login` to sign in"
 )
 
 func (m Model) claudeElapsedPercent(resetAt time.Time, window time.Duration) float64 {
@@ -32,7 +33,7 @@ func (m Model) claudeSectionBody() string {
 	if m.claudeAuth == nil && m.claudeEnabled {
 		b.WriteString(pctStyle(red).Render("  ⚠️  credentials not found"))
 		b.WriteByte('\n')
-		b.WriteString(dimStyle.Render("  Hint: run `claude /login` to sign in"))
+		b.WriteString(dimStyle.Render(claudeLoginHint))
 		b.WriteByte('\n')
 		return b.String()
 	}
@@ -50,8 +51,8 @@ func (m Model) claudeSectionBody() string {
 		}
 		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.claudeErr, m.claudeRetries, maxRetries)))
 		b.WriteByte('\n')
-		if strings.Contains(m.claudeErr, "401") {
-			b.WriteString(dimStyle.Render("  Hint: run `claude /login` to refresh credentials"))
+		if m.claudeAuthFailed {
+			b.WriteString(dimStyle.Render(claudeLoginHint))
 			b.WriteByte('\n')
 		}
 		if m.claudeUsage == nil {

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -29,6 +29,14 @@ func (m Model) claudeSection() string {
 func (m Model) claudeSectionBody() string {
 	var b strings.Builder
 
+	if m.claudeAuth == nil && m.claudeEnabled {
+		b.WriteString(pctStyle(red).Render("  ⚠️  credentials not found"))
+		b.WriteByte('\n')
+		b.WriteString(dimStyle.Render("  Hint: run `claude /login` to sign in"))
+		b.WriteByte('\n')
+		return b.String()
+	}
+
 	if m.claudeUsage == nil && m.claudeErr == "" {
 		b.WriteString(dimStyle.Render("  Loading..."))
 		b.WriteByte('\n')
@@ -42,6 +50,10 @@ func (m Model) claudeSectionBody() string {
 		}
 		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.claudeErr, m.claudeRetries, maxRetries)))
 		b.WriteByte('\n')
+		if strings.Contains(m.claudeErr, "401") {
+			b.WriteString(dimStyle.Render("  Hint: run `claude /login` to refresh credentials"))
+			b.WriteByte('\n')
+		}
 		if m.claudeUsage == nil {
 			return b.String()
 		}

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -13,8 +13,9 @@ import (
 const (
 	claudeSessionWindow = 5 * time.Hour
 	claudeWeeklyWindow  = 7 * 24 * time.Hour
-	claudeLoginHint     = "  Hint: run `claude /login` to sign in"
 )
+
+var claudeLoginHintLine = "  Hint: " + claude.LoginHint
 
 func (m Model) claudeElapsedPercent(resetAt time.Time, window time.Duration) float64 {
 	if !m.claudeUIConfig.PaceTick {
@@ -33,7 +34,7 @@ func (m Model) claudeSectionBody() string {
 	if m.claudeAuth == nil && m.claudeEnabled {
 		b.WriteString(pctStyle(red).Render("  ⚠️  credentials not found"))
 		b.WriteByte('\n')
-		b.WriteString(dimStyle.Render(claudeLoginHint))
+		b.WriteString(dimStyle.Render(claudeLoginHintLine))
 		b.WriteByte('\n')
 		return b.String()
 	}
@@ -52,7 +53,7 @@ func (m Model) claudeSectionBody() string {
 		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.claudeErr, m.claudeRetries, maxRetries)))
 		b.WriteByte('\n')
 		if m.claudeAuthFailed {
-			b.WriteString(dimStyle.Render(claudeLoginHint))
+			b.WriteString(dimStyle.Render(claudeLoginHintLine))
 			b.WriteByte('\n')
 		}
 		if m.claudeUsage == nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,13 +72,15 @@ type Model struct {
 	claudeUsage   *claude.Usage
 	claudeErr     string
 	claudeRetries int
+	claudeEnabled bool
 }
 
-func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth, codexUIConfig config.CodexUIConfig, claudeUIConfig config.ClaudeUIConfig, orUIConfig config.OpenRouterUIConfig, version string) Model {
+func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth, claudeEnabled bool, codexUIConfig config.CodexUIConfig, claudeUIConfig config.ClaudeUIConfig, orUIConfig config.OpenRouterUIConfig, version string) Model {
 	return Model{
 		codexAuth:      codexAuth,
 		orAuth:         orAuth,
 		claudeAuth:     claudeAuth,
+		claudeEnabled:  claudeEnabled,
 		codexUIConfig:  codexUIConfig,
 		claudeUIConfig: claudeUIConfig,
 		orUIConfig:     orUIConfig,
@@ -250,7 +252,7 @@ func (m Model) barWidth() int {
 func (m Model) View() string {
 	var b strings.Builder
 
-	if m.claudeAuth != nil {
+	if m.claudeAuth != nil || m.claudeEnabled {
 		b.WriteString(m.claudeSection())
 	}
 	if m.codexAuth != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -68,23 +69,40 @@ type Model struct {
 	orRetries int
 	orMetric  orMetric
 
-	claudeAuth    *claude.Auth
-	claudeUsage   *claude.Usage
-	claudeErr     string
-	claudeRetries int
-	claudeEnabled bool
+	claudeAuth        *claude.Auth
+	claudeUsage       *claude.Usage
+	claudeErr         string
+	claudeRetries     int
+	claudeEnabled     bool
+	claudeAuthFailed  bool
 }
 
-func New(codexAuth *codex.Auth, orAuth *openrouter.Auth, claudeAuth *claude.Auth, claudeEnabled bool, codexUIConfig config.CodexUIConfig, claudeUIConfig config.ClaudeUIConfig, orUIConfig config.OpenRouterUIConfig, version string) Model {
+type CodexProvider struct {
+	Auth *codex.Auth
+	UI   config.CodexUIConfig
+}
+
+type OpenRouterProvider struct {
+	Auth *openrouter.Auth
+	UI   config.OpenRouterUIConfig
+}
+
+type ClaudeProvider struct {
+	Auth    *claude.Auth
+	Enabled bool
+	UI      config.ClaudeUIConfig
+}
+
+func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, version string) Model {
 	return Model{
-		codexAuth:      codexAuth,
-		orAuth:         orAuth,
-		claudeAuth:     claudeAuth,
-		claudeEnabled:  claudeEnabled,
-		codexUIConfig:  codexUIConfig,
-		claudeUIConfig: claudeUIConfig,
-		orUIConfig:     orUIConfig,
-		orMetric:       parseMetric(orUIConfig.Metric),
+		codexAuth:      cx.Auth,
+		orAuth:         or.Auth,
+		claudeAuth:     cl.Auth,
+		claudeEnabled:  cl.Enabled,
+		codexUIConfig:  cx.UI,
+		claudeUIConfig: cl.UI,
+		orUIConfig:     or.UI,
+		orMetric:       parseMetric(or.UI.Metric),
 		version:        version,
 		nextRefresh:    time.Now().Add(refreshInterval),
 	}
@@ -194,12 +212,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.claudeErr = msg.err.Error()
+			m.claudeAuthFailed = errors.Is(msg.err, claude.ErrUnauthorized)
 			if cmd := m.scheduleRetry("claude", &m.claudeRetries, msg.err, func(g uint64) tea.Msg { return claudeRetryMsg{gen: g} }); cmd != nil {
 				return m, cmd
 			}
 		} else {
 			m.claudeUsage = msg.usage
 			m.claudeErr = ""
+			m.claudeAuthFailed = false
 			m.claudeRetries = 0
 			m.lastFetch = time.Now()
 			slog.Debug("claude usage refresh succeeded")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -69,12 +69,12 @@ type Model struct {
 	orRetries int
 	orMetric  orMetric
 
-	claudeAuth        *claude.Auth
-	claudeUsage       *claude.Usage
-	claudeErr         string
-	claudeRetries     int
-	claudeEnabled     bool
-	claudeAuthFailed  bool
+	claudeAuth       *claude.Auth
+	claudeUsage      *claude.Usage
+	claudeErr        string
+	claudeRetries    int
+	claudeEnabled    bool
+	claudeAuthFailed bool
 }
 
 type CodexProvider struct {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -122,6 +122,28 @@ func TestClaudeSectionRenderSnapshot(t *testing.T) {
 	assert.Equal(t, string(want), got, "claude section mismatch")
 }
 
+func TestClaudeSectionShowsLoginHintWhenCredentialsMissing(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{width: 85, claudeEnabled: true}
+	got := m.claudeSection()
+	assert.Contains(t, got, "credentials not found")
+	assert.Contains(t, got, claude.LoginHint)
+}
+
+func TestClaudeSectionShowsLoginHintOnAuthFailure(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{
+		width:            85,
+		claudeEnabled:    true,
+		claudeAuth:       &claude.Auth{},
+		claudeErr:        "Anthropic API 401: invalid token: unauthorized",
+		claudeAuthFailed: true,
+	}
+	got := m.claudeSection()
+	assert.Contains(t, got, "401")
+	assert.Contains(t, got, claude.LoginHint)
+}
+
 func TestOpenRouterSectionRenderSnapshot(t *testing.T) {
 	forceTrueColorProfile(t)
 

--- a/pkg/claude/usage.go
+++ b/pkg/claude/usage.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"time"
 )
+
+var ErrUnauthorized = errors.New("unauthorized")
 
 type Usage struct {
 	SubscriptionType string
@@ -68,6 +71,9 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds(), "body", string(body))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("Anthropic API %s: %w", formatErrorBody(resp.StatusCode, body), ErrUnauthorized)
+		}
 		return nil, fmt.Errorf("Anthropic API %s", formatErrorBody(resp.StatusCode, body))
 	}
 	io.Copy(io.Discard, resp.Body)

--- a/pkg/claude/usage.go
+++ b/pkg/claude/usage.go
@@ -14,6 +14,8 @@ import (
 
 var ErrUnauthorized = errors.New("unauthorized")
 
+const LoginHint = "run `claude /login` to sign in"
+
 type Usage struct {
 	SubscriptionType string
 	RateLimitTier    string


### PR DESCRIPTION
## Summary
- Render the Claude section even when credentials fail to load, with a `claude /login` hint instead of silently hiding the panel
- Print the same hint to stderr at startup when Claude is enabled but credentials can't be read
- Append the hint below the in-TUI error bar on 401 responses from the Anthropic API