### PR TITLE
Show login hint when Codex credentials are missing or invalid

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -77,6 +77,7 @@ func main() {
 		if err != nil {
 			slog.Warn("codex auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: codex: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Hint:", codex.LoginHint)
 		} else {
 			codexAuth = auth
 			slog.Info("codex provider enabled")
@@ -113,14 +114,14 @@ func main() {
 		}
 	}
 
-	if codexAuth == nil && orAuth == nil && claudeAuth == nil && !cfg.Providers.Anthropic.Enabled {
+	if codexAuth == nil && orAuth == nil && claudeAuth == nil && !cfg.Providers.Codex.Enabled && !cfg.Providers.Anthropic.Enabled {
 		slog.Error("no providers available")
 		fmt.Fprintf(os.Stderr, "Error: no providers available\n")
 		os.Exit(1)
 	}
 
 	p := tea.NewProgram(tui.New(
-		tui.CodexProvider{Auth: codexAuth, UI: cfg.CodexUI},
+		tui.CodexProvider{Auth: codexAuth, Enabled: cfg.Providers.Codex.Enabled, UI: cfg.CodexUI},
 		tui.OpenRouterProvider{Auth: orAuth, UI: cfg.OpenRouterUI},
 		tui.ClaudeProvider{Auth: claudeAuth, Enabled: cfg.Providers.Anthropic.Enabled, UI: cfg.ClaudeUI},
 		AppVersion,

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -15,7 +15,7 @@ const (
 	claudeWeeklyWindow  = 7 * 24 * time.Hour
 )
 
-var claudeLoginHintLine = "  Hint: " + claude.LoginHint
+const claudeLoginHintLine = "  Hint: " + claude.LoginHint
 
 func (m Model) claudeElapsedPercent(resetAt time.Time, window time.Duration) float64 {
 	if !m.claudeUIConfig.PaceTick {

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -10,7 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-var codexLoginHintLine = "  Hint: " + codex.LoginHint
+const codexLoginHintLine = "  Hint: " + codex.LoginHint
 
 func (m Model) codexElapsedPercent(w *codex.UsageWindow) float64 {
 	if !m.codexUIConfig.PaceTick || w == nil || w.LimitWindowSeconds <= 0 {

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -10,6 +10,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+var codexLoginHintLine = "  Hint: " + codex.LoginHint
+
 func (m Model) codexElapsedPercent(w *codex.UsageWindow) float64 {
 	if !m.codexUIConfig.PaceTick || w == nil || w.LimitWindowSeconds <= 0 {
 		return -1
@@ -24,6 +26,14 @@ func (m Model) codexSection() string {
 func (m Model) codexSectionBody() string {
 	var b strings.Builder
 
+	if m.codexAuth == nil && m.codexEnabled {
+		b.WriteString(pctStyle(red).Render("  ⚠️  credentials not found"))
+		b.WriteByte('\n')
+		b.WriteString(dimStyle.Render(codexLoginHintLine))
+		b.WriteByte('\n')
+		return b.String()
+	}
+
 	if m.codexUsage == nil && m.codexErr == "" {
 		b.WriteString(dimStyle.Render("  Loading..."))
 		b.WriteByte('\n')
@@ -37,6 +47,10 @@ func (m Model) codexSectionBody() string {
 		}
 		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.codexErr, m.codexRetries, maxRetries)))
 		b.WriteByte('\n')
+		if m.codexAuthFailed {
+			b.WriteString(dimStyle.Render(codexLoginHintLine))
+			b.WriteByte('\n')
+		}
 		if m.codexUsage == nil {
 			return b.String()
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -58,10 +58,12 @@ type Model struct {
 	claudeUIConfig config.ClaudeUIConfig
 	orUIConfig     config.OpenRouterUIConfig
 
-	codexAuth    *codex.Auth
-	codexUsage   *codex.Usage
-	codexErr     string
-	codexRetries int
+	codexAuth       *codex.Auth
+	codexUsage      *codex.Usage
+	codexErr        string
+	codexRetries    int
+	codexEnabled    bool
+	codexAuthFailed bool
 
 	orAuth    *openrouter.Auth
 	orUsage   *openrouter.Usage
@@ -78,8 +80,9 @@ type Model struct {
 }
 
 type CodexProvider struct {
-	Auth *codex.Auth
-	UI   config.CodexUIConfig
+	Auth    *codex.Auth
+	Enabled bool
+	UI      config.CodexUIConfig
 }
 
 type OpenRouterProvider struct {
@@ -96,6 +99,7 @@ type ClaudeProvider struct {
 func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, version string) Model {
 	return Model{
 		codexAuth:      cx.Auth,
+		codexEnabled:   cx.Enabled,
 		orAuth:         or.Auth,
 		claudeAuth:     cl.Auth,
 		claudeEnabled:  cl.Enabled,
@@ -169,12 +173,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.codexErr = msg.err.Error()
+			m.codexAuthFailed = errors.Is(msg.err, codex.ErrUnauthorized)
 			if cmd := m.scheduleRetry("codex", &m.codexRetries, msg.err, func(g uint64) tea.Msg { return codexRetryMsg{gen: g} }); cmd != nil {
 				return m, cmd
 			}
 		} else {
 			m.codexUsage = msg.usage
 			m.codexErr = ""
+			m.codexAuthFailed = false
 			m.codexRetries = 0
 			m.lastFetch = time.Now()
 			slog.Debug("codex usage refresh succeeded")
@@ -275,7 +281,7 @@ func (m Model) View() string {
 	if m.claudeAuth != nil || m.claudeEnabled {
 		b.WriteString(m.claudeSection())
 	}
-	if m.codexAuth != nil {
+	if m.codexAuth != nil || m.codexEnabled {
 		b.WriteString(m.codexSection())
 	}
 	if m.orAuth != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -122,6 +122,28 @@ func TestClaudeSectionRenderSnapshot(t *testing.T) {
 	assert.Equal(t, string(want), got, "claude section mismatch")
 }
 
+func TestCodexSectionShowsLoginHintWhenCredentialsMissing(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{width: 85, codexEnabled: true}
+	got := m.codexSection()
+	assert.Contains(t, got, "credentials not found")
+	assert.Contains(t, got, codex.LoginHint)
+}
+
+func TestCodexSectionShowsLoginHintOnAuthFailure(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{
+		width:           85,
+		codexEnabled:    true,
+		codexAuth:       &codex.Auth{},
+		codexErr:        "Codex API 401: invalid token: unauthorized",
+		codexAuthFailed: true,
+	}
+	got := m.codexSection()
+	assert.Contains(t, got, "401")
+	assert.Contains(t, got, codex.LoginHint)
+}
+
 func TestClaudeSectionShowsLoginHintWhenCredentialsMissing(t *testing.T) {
 	forceTrueColorProfile(t)
 	m := Model{width: 85, claudeEnabled: true}

--- a/pkg/codex/usage.go
+++ b/pkg/codex/usage.go
@@ -2,12 +2,17 @@ package codex
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
 )
+
+var ErrUnauthorized = errors.New("unauthorized")
+
+const LoginHint = "run `codex login` to sign in"
 
 type Usage struct {
 	PlanType            string       `json:"plan_type"`
@@ -87,6 +92,9 @@ func FetchUsage(auth *Auth) (*Usage, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds(), "body", string(body))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("Codex API %s: %w", formatErrorBody(resp.StatusCode, body), ErrUnauthorized)
+		}
 		return nil, fmt.Errorf("Codex API %s", formatErrorBody(resp.StatusCode, body))
 	}
 


### PR DESCRIPTION
## Summary
- Add `codex.ErrUnauthorized` sentinel and exported `codex.LoginHint` constant; wrap 401 responses with `%w` so the TUI can detect auth failure via `errors.Is`.
- Render the Codex section with a `credentials not found` empty state when the provider is enabled but auth is missing, instead of silently hiding it.
- Show `Hint: run \`codex login\` to sign in` below the in-TUI error bar on 401 and on stderr when `~/.codex/auth.json` fails to load.
- Extend `tui.CodexProvider` with `Enabled` and keep launching when Codex is enabled but unauthed (matches the Claude pattern from #22).
- Tests for both new render paths.