### PR TITLE
Show hint when OpenRouter API key is missing or invalid

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -90,6 +90,7 @@ func main() {
 		if err != nil {
 			slog.Warn("openrouter auth unavailable", "error", err)
 			fmt.Fprintf(os.Stderr, "Warning: openrouter: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Hint:", openrouter.LoginHint)
 		} else {
 			orAuth = auth
 			slog.Info("openrouter provider enabled")
@@ -114,7 +115,7 @@ func main() {
 		}
 	}
 
-	if codexAuth == nil && orAuth == nil && claudeAuth == nil && !cfg.Providers.Codex.Enabled && !cfg.Providers.Anthropic.Enabled {
+	if codexAuth == nil && orAuth == nil && claudeAuth == nil && !cfg.Providers.Codex.Enabled && !cfg.Providers.Anthropic.Enabled && !cfg.Providers.OpenRouter.Enabled {
 		slog.Error("no providers available")
 		fmt.Fprintf(os.Stderr, "Error: no providers available\n")
 		os.Exit(1)
@@ -122,7 +123,7 @@ func main() {
 
 	p := tea.NewProgram(tui.New(
 		tui.CodexProvider{Auth: codexAuth, Enabled: cfg.Providers.Codex.Enabled, UI: cfg.CodexUI},
-		tui.OpenRouterProvider{Auth: orAuth, UI: cfg.OpenRouterUI},
+		tui.OpenRouterProvider{Auth: orAuth, Enabled: cfg.Providers.OpenRouter.Enabled, UI: cfg.OpenRouterUI},
 		tui.ClaudeProvider{Auth: claudeAuth, Enabled: cfg.Providers.Anthropic.Enabled, UI: cfg.ClaudeUI},
 		AppVersion,
 	), tea.WithAltScreen())

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -65,11 +65,13 @@ type Model struct {
 	codexEnabled    bool
 	codexAuthFailed bool
 
-	orAuth    *openrouter.Auth
-	orUsage   *openrouter.Usage
-	orErr     string
-	orRetries int
-	orMetric  orMetric
+	orAuth       *openrouter.Auth
+	orUsage      *openrouter.Usage
+	orErr        string
+	orRetries    int
+	orMetric     orMetric
+	orEnabled    bool
+	orAuthFailed bool
 
 	claudeAuth       *claude.Auth
 	claudeUsage      *claude.Usage
@@ -86,8 +88,9 @@ type CodexProvider struct {
 }
 
 type OpenRouterProvider struct {
-	Auth *openrouter.Auth
-	UI   config.OpenRouterUIConfig
+	Auth    *openrouter.Auth
+	Enabled bool
+	UI      config.OpenRouterUIConfig
 }
 
 type ClaudeProvider struct {
@@ -101,6 +104,7 @@ func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, version str
 		codexAuth:      cx.Auth,
 		codexEnabled:   cx.Enabled,
 		orAuth:         or.Auth,
+		orEnabled:      or.Enabled,
 		claudeAuth:     cl.Auth,
 		claudeEnabled:  cl.Enabled,
 		codexUIConfig:  cx.UI,
@@ -192,6 +196,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.orErr = msg.err.Error()
+			m.orAuthFailed = errors.Is(msg.err, openrouter.ErrUnauthorized)
 			if cmd := m.scheduleRetry("openrouter", &m.orRetries, msg.err, func(g uint64) tea.Msg { return orRetryMsg{gen: g} }); cmd != nil {
 				return m, cmd
 			}
@@ -207,6 +212,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.orUsage = msg.usage
 			m.orErr = ""
+			m.orAuthFailed = false
 			m.orRetries = 0
 			m.lastFetch = time.Now()
 			slog.Debug("openrouter usage refresh succeeded")
@@ -284,7 +290,7 @@ func (m Model) View() string {
 	if m.codexAuth != nil || m.codexEnabled {
 		b.WriteString(m.codexSection())
 	}
-	if m.orAuth != nil {
+	if m.orAuth != nil || m.orEnabled {
 		b.WriteString(m.orSection())
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -166,6 +166,28 @@ func TestClaudeSectionShowsLoginHintOnAuthFailure(t *testing.T) {
 	assert.Contains(t, got, claude.LoginHint)
 }
 
+func TestOpenRouterSectionShowsHintWhenCredentialsMissing(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{width: 85, orEnabled: true}
+	got := m.orSection()
+	assert.Contains(t, got, "credentials not found")
+	assert.Contains(t, got, openrouter.LoginHint)
+}
+
+func TestOpenRouterSectionShowsHintOnAuthFailure(t *testing.T) {
+	forceTrueColorProfile(t)
+	m := Model{
+		width:        85,
+		orEnabled:    true,
+		orAuth:       &openrouter.Auth{APIKey: "sk-or-bad"},
+		orErr:        "OpenRouter API /key 401: invalid token: unauthorized",
+		orAuthFailed: true,
+	}
+	got := m.orSection()
+	assert.Contains(t, got, "401")
+	assert.Contains(t, got, openrouter.LoginHint)
+}
+
 func TestOpenRouterSectionRenderSnapshot(t *testing.T) {
 	forceTrueColorProfile(t)
 

--- a/internal/tui/openrouter_view.go
+++ b/internal/tui/openrouter_view.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lwlee2608/tokentop/pkg/openrouter"
 	"github.com/mattn/go-runewidth"
 )
+
+const orLoginHintLine = "  Hint: " + openrouter.LoginHint
 
 func redactAPIKey(key string) string {
 	if len(key) <= 8 {
@@ -62,6 +65,14 @@ func (m Model) orSection() string {
 func (m Model) orSectionBody() string {
 	var b strings.Builder
 
+	if m.orAuth == nil && m.orEnabled {
+		b.WriteString(pctStyle(red).Render("  ⚠️  credentials not found"))
+		b.WriteByte('\n')
+		b.WriteString(dimStyle.Render(orLoginHintLine))
+		b.WriteByte('\n')
+		return b.String()
+	}
+
 	if m.orUsage == nil && m.orErr == "" {
 		b.WriteString(dimStyle.Render("  Loading..."))
 		b.WriteByte('\n')
@@ -75,6 +86,10 @@ func (m Model) orSectionBody() string {
 		}
 		b.WriteString(pctStyle(c).Render(fmt.Sprintf("  ⚠️  %s (retry %d/%d)", m.orErr, m.orRetries, maxRetries)))
 		b.WriteByte('\n')
+		if m.orAuthFailed {
+			b.WriteString(dimStyle.Render(orLoginHintLine))
+			b.WriteByte('\n')
+		}
 		if m.orUsage == nil {
 			return b.String()
 		}

--- a/pkg/openrouter/auth.go
+++ b/pkg/openrouter/auth.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const LoginHint = "set OPENROUTER_API_KEY env var (see openrouter.ai/keys)"
+
 type Auth struct {
 	APIKey string `mask:"first=3,last=4"`
 }

--- a/pkg/openrouter/usage.go
+++ b/pkg/openrouter/usage.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9,6 +10,8 @@ import (
 	"sort"
 	"time"
 )
+
+var ErrUnauthorized = errors.New("unauthorized")
 
 var baseURL = "https://openrouter.ai/api/v1"
 
@@ -383,6 +386,9 @@ func doJSON(client *http.Client, auth *Auth, method, url string, target any) err
 
 	if resp.StatusCode != http.StatusOK {
 		logger.Warn("request returned non-ok status", "status", resp.StatusCode, "duration_ms", time.Since(started).Milliseconds(), "body", string(body))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("OpenRouter API %s %s: %w", url, formatErrorBody(resp.StatusCode, body), ErrUnauthorized)
+		}
 		return fmt.Errorf("OpenRouter API %s %s", url, formatErrorBody(resp.StatusCode, body))
 	}
 


### PR DESCRIPTION
## Summary
- Add `openrouter.LoginHint` constant pointing users to set the `OPENROUTER_API_KEY` env var
- Add `openrouter.ErrUnauthorized` sentinel; wrap 401 responses in `doJSON` with `%w`
- Print the hint to stderr when `LoadAuth` fails at startup
- Render an empty-state with the hint in the TUI when OpenRouter is enabled but unauthed
- Render the hint below the error bar when a refresh hits 401
- Add `Enabled` to `OpenRouterProvider` so the section keeps showing when the key is missing
- Tests mirror the Claude/Codex coverage