### PR TITLE
Add configurable refresh interval

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -125,6 +125,7 @@ func main() {
 		tui.CodexProvider{Auth: codexAuth, Enabled: cfg.Providers.Codex.Enabled, UI: cfg.CodexUI},
 		tui.OpenRouterProvider{Auth: orAuth, Enabled: cfg.Providers.OpenRouter.Enabled, UI: cfg.OpenRouterUI},
 		tui.ClaudeProvider{Auth: claudeAuth, Enabled: cfg.Providers.Anthropic.Enabled, UI: cfg.ClaudeUI},
+		cfg.Refresh,
 		AppVersion,
 	), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@ log:
   level: info
   path: ""
 
+refresh:
+  interval_seconds: 300
+
 providers:
   codex:
     enabled: true
@@ -48,6 +51,12 @@ openrouter_ui:
 |---------|--------|---------|-------------|
 | `level` | string | `info`  | One of `debug`, `info`, `warn`, `error`, or `off` to disable logging entirely. |
 | `path`  | string | `""`    | Log file path. When empty, logs go to `$XDG_STATE_HOME/tokentop/tokentop.log` (or `~/.local/state/tokentop/tokentop.log`). |
+
+### `refresh`
+
+| Key                | Type | Default | Description |
+|--------------------|------|---------|-------------|
+| `interval_seconds` | int  | `300`   | Seconds between automatic usage refreshes. Must be greater than zero. |
 
 ### `providers`
 
@@ -110,4 +119,3 @@ openrouter_ui:
   top_models: false
   api_keys: false
 ```
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 
 type Config struct {
 	Log          LogConfig          `mapstructure:"log"`
+	Refresh      RefreshConfig      `mapstructure:"refresh"`
 	Providers    ProvidersConfig    `mapstructure:"providers"`
 	CodexUI      CodexUIConfig      `mapstructure:"codex_ui"`
 	ClaudeUI     ClaudeUIConfig     `mapstructure:"claude_ui"`
@@ -24,6 +26,10 @@ type Config struct {
 type LogConfig struct {
 	Level string `mapstructure:"level"`
 	Path  string `mapstructure:"path"`
+}
+
+type RefreshConfig struct {
+	IntervalSeconds int `mapstructure:"interval_seconds"`
 }
 
 type ProvidersConfig struct {
@@ -70,6 +76,9 @@ func Load() (*Config, error) {
 	a.AutomaticEnv()
 
 	cfg := &Config{
+		Refresh: RefreshConfig{
+			IntervalSeconds: 300,
+		},
 		CodexUI: CodexUIConfig{
 			PaceTick: true,
 		},
@@ -106,6 +115,9 @@ func Load() (*Config, error) {
 		if err := a.Unmarshal(cfg); err != nil {
 			return nil, err
 		}
+	}
+	if cfg.Refresh.IntervalSeconds <= 0 {
+		return nil, fmt.Errorf("refresh.interval_seconds must be greater than 0")
 	}
 
 	return cfg, nil

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -2,6 +2,9 @@ log:
   level: info
   path: ""
 
+refresh:
+  interval_seconds: 300
+
 providers:
   codex:
     enabled: true
@@ -23,4 +26,3 @@ openrouter_ui:
   top_models: true
   api_keys: false
   metric: spend  # spend | requests | tokens
-

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	refreshInterval = 5 * time.Minute
-	retryDelay      = 5 * time.Second
-	maxRetries      = 3
+	retryDelay = 5 * time.Second
+	maxRetries = 3
 )
 
 type tickMsg time.Time
@@ -49,14 +48,15 @@ type claudeUsageMsg struct {
 type claudeRetryMsg struct{ gen uint64 }
 
 type Model struct {
-	version        string
-	width          int
-	lastFetch      time.Time
-	nextRefresh    time.Time
-	gen            uint64
-	codexUIConfig  config.CodexUIConfig
-	claudeUIConfig config.ClaudeUIConfig
-	orUIConfig     config.OpenRouterUIConfig
+	version         string
+	width           int
+	lastFetch       time.Time
+	nextRefresh     time.Time
+	refreshInterval time.Duration
+	gen             uint64
+	codexUIConfig   config.CodexUIConfig
+	claudeUIConfig  config.ClaudeUIConfig
+	orUIConfig      config.OpenRouterUIConfig
 
 	codexAuth       *codex.Auth
 	codexUsage      *codex.Usage
@@ -99,25 +99,27 @@ type ClaudeProvider struct {
 	UI      config.ClaudeUIConfig
 }
 
-func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, version string) Model {
+func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, refresh config.RefreshConfig, version string) Model {
+	refreshInterval := time.Duration(refresh.IntervalSeconds) * time.Second
 	return Model{
-		codexAuth:      cx.Auth,
-		codexEnabled:   cx.Enabled,
-		orAuth:         or.Auth,
-		orEnabled:      or.Enabled,
-		claudeAuth:     cl.Auth,
-		claudeEnabled:  cl.Enabled,
-		codexUIConfig:  cx.UI,
-		claudeUIConfig: cl.UI,
-		orUIConfig:     or.UI,
-		orMetric:       parseMetric(or.UI.Metric),
-		version:        version,
-		nextRefresh:    time.Now().Add(refreshInterval),
+		codexAuth:       cx.Auth,
+		codexEnabled:    cx.Enabled,
+		orAuth:          or.Auth,
+		orEnabled:       or.Enabled,
+		claudeAuth:      cl.Auth,
+		claudeEnabled:   cl.Enabled,
+		codexUIConfig:   cx.UI,
+		claudeUIConfig:  cl.UI,
+		orUIConfig:      or.UI,
+		orMetric:        parseMetric(or.UI.Metric),
+		version:         version,
+		refreshInterval: refreshInterval,
+		nextRefresh:     time.Now().Add(refreshInterval),
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{tick(), countdown()}
+	cmds := []tea.Cmd{m.tick(), countdown()}
 	if m.codexAuth != nil {
 		cmds = append(cmds, fetchCodexUsage(m.codexAuth, m.gen))
 	}
@@ -255,7 +257,7 @@ func (m Model) scheduleRetry(provider string, retries *int, err error, mkMsg fun
 }
 
 func (m Model) refresh() (tea.Model, tea.Cmd) {
-	m.nextRefresh = time.Now().Add(refreshInterval)
+	m.nextRefresh = time.Now().Add(m.refreshInterval)
 	m.gen++
 	m.codexRetries = 0
 	m.orRetries = 0
@@ -271,7 +273,7 @@ func (m Model) refresh() (tea.Model, tea.Cmd) {
 	if m.claudeAuth != nil {
 		cmds = append(cmds, fetchClaudeUsage(m.claudeAuth, m.gen))
 	}
-	cmds = append(cmds, tick())
+	cmds = append(cmds, m.tick())
 	return m, tea.Batch(cmds...)
 }
 
@@ -439,8 +441,8 @@ func fetchORUsage(auth *openrouter.Auth, gen uint64) tea.Cmd {
 	}
 }
 
-func tick() tea.Cmd {
-	return tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
+func (m Model) tick() tea.Cmd {
+	return tea.Tick(m.refreshInterval, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }


### PR DESCRIPTION
## Context
The refresh timer was fixed at 300 seconds. This lets users tune automatic usage refresh frequency from config.

## Summary
- Add `refresh.interval_seconds` with a 300-second default
- Use the configured interval for automatic TUI refresh scheduling
- Document the new config field