### PR TITLE
Add ui.duration_days config to show days in reset countdowns

### DIFF
--- a/cmd/tokentop/main.go
+++ b/cmd/tokentop/main.go
@@ -125,6 +125,7 @@ func main() {
 		tui.CodexProvider{Auth: codexAuth, Enabled: cfg.Providers.Codex.Enabled, UI: cfg.CodexUI},
 		tui.OpenRouterProvider{Auth: orAuth, Enabled: cfg.Providers.OpenRouter.Enabled, UI: cfg.OpenRouterUI},
 		tui.ClaudeProvider{Auth: claudeAuth, Enabled: cfg.Providers.Anthropic.Enabled, UI: cfg.ClaudeUI},
+		cfg.UI,
 		cfg.Refresh,
 		AppVersion,
 	), tea.WithAltScreen())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Log          LogConfig          `mapstructure:"log"`
 	Refresh      RefreshConfig      `mapstructure:"refresh"`
 	Providers    ProvidersConfig    `mapstructure:"providers"`
+	UI           UIConfig           `mapstructure:"ui"`
 	CodexUI      CodexUIConfig      `mapstructure:"codex_ui"`
 	ClaudeUI     ClaudeUIConfig     `mapstructure:"claude_ui"`
 	OpenRouterUI OpenRouterUIConfig `mapstructure:"openrouter_ui"`
@@ -40,6 +41,10 @@ type ProvidersConfig struct {
 
 type ProviderConfig struct {
 	Enabled bool `mapstructure:"enabled"`
+}
+
+type UIConfig struct {
+	DurationDays bool `mapstructure:"duration_days"`
 }
 
 type CodexUIConfig struct {

--- a/internal/config/default_config.yaml
+++ b/internal/config/default_config.yaml
@@ -26,3 +26,6 @@ openrouter_ui:
   top_models: true
   api_keys: false
   metric: spend  # spend | requests | tokens
+
+ui:
+  duration_days: false

--- a/internal/tui/claude_view.go
+++ b/internal/tui/claude_view.go
@@ -72,13 +72,13 @@ func (m Model) claudeSectionBody() string {
 	for i, l := range u.Limits {
 		resetInfo := ""
 		if !l.ResetAt.IsZero() {
-			resetInfo = timeUntil(l.ResetAt)
+			resetInfo = m.timeUntil(l.ResetAt)
 		}
 		pace := -1.0
 		if d := claudeLimitWindow(l); d > 0 {
 			pace = m.claudeElapsedPercent(l.ResetAt, d)
 		}
-		b.WriteString(renderCompactBar(fmt.Sprintf("%-*s", labelWidth, labels[i]), l.Percent, pace, bw, resetInfo))
+		b.WriteString(m.renderCompactBar(fmt.Sprintf("%-*s", labelWidth, labels[i]), l.Percent, pace, bw, resetInfo))
 	}
 
 	b.WriteByte('\n')

--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -71,14 +71,14 @@ func (m Model) codexSectionBody() string {
 	b.WriteByte('\n')
 
 	if w := u.RateLimit.PrimaryWindow; w != nil {
-		b.WriteString(renderCompactBar("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
+		b.WriteString(m.renderCompactBar("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 	}
 	if w := u.RateLimit.SecondaryWindow; w != nil {
-		b.WriteString(renderCompactBar("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
+		b.WriteString(m.renderCompactBar("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 	}
 	if m.codexUIConfig.CodeReview {
 		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
-			b.WriteString(renderCompactBar("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, timeUntil(w.ResetTime())))
+			b.WriteString(m.renderCompactBar("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 		}
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,6 +54,7 @@ type Model struct {
 	nextRefresh     time.Time
 	refreshInterval time.Duration
 	gen             uint64
+	uiConfig        config.UIConfig
 	codexUIConfig   config.CodexUIConfig
 	claudeUIConfig  config.ClaudeUIConfig
 	orUIConfig      config.OpenRouterUIConfig
@@ -99,7 +100,7 @@ type ClaudeProvider struct {
 	UI      config.ClaudeUIConfig
 }
 
-func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, refresh config.RefreshConfig, version string) Model {
+func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, ui config.UIConfig, refresh config.RefreshConfig, version string) Model {
 	refreshInterval := time.Duration(refresh.IntervalSeconds) * time.Second
 	return Model{
 		codexAuth:       cx.Auth,
@@ -108,6 +109,7 @@ func New(cx CodexProvider, or OpenRouterProvider, cl ClaudeProvider, refresh con
 		orEnabled:       or.Enabled,
 		claudeAuth:      cl.Auth,
 		claudeEnabled:   cl.Enabled,
+		uiConfig:        ui,
 		codexUIConfig:   cx.UI,
 		claudeUIConfig:  cl.UI,
 		orUIConfig:      or.UI,
@@ -395,13 +397,20 @@ func renderBar(label string, usedPercent, elapsedPercent float64, barWidth int, 
 	return b.String()
 }
 
-const compactResetWidth = 8 // fixed width for reset info, e.g. "168h 59m"
+// fixed width for reset info, e.g. "168h 59m" or "6d 23h 59m" with duration_days
+func (m Model) resetInfoWidth() int {
+	if m.uiConfig.DurationDays {
+		return 10
+	}
+	return 8
+}
 
-func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
+func (m Model) renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidth int, resetInfo string) string {
 	used := math.Min(usedPercent, 100)
 
 	// Shrink bar to fit label, pct, and fixed-width reset info on one line
-	overhead := barPadding + compactResetWidth - 2
+	resetWidth := m.resetInfoWidth()
+	overhead := barPadding + resetWidth - 2
 	compactBarWidth := barWidth - overhead
 	compactBarWidth = max(compactBarWidth, 10)
 
@@ -422,7 +431,7 @@ func renderCompactBar(label string, usedPercent, elapsedPercent float64, barWidt
 		}
 	}
 
-	reset := fmt.Sprintf("%*s", compactResetWidth, resetInfo)
+	reset := fmt.Sprintf("%*s", resetWidth, resetInfo)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "  %s%s  %s  %s\n",
@@ -467,15 +476,18 @@ func elapsedPercent(resetAt time.Time, windowDuration time.Duration) float64 {
 	return float64(windowDuration-remaining) / float64(windowDuration) * 100
 }
 
-func timeUntil(t time.Time) string {
+func (m Model) timeUntil(t time.Time) string {
 	d := time.Until(t)
 	if d < 0 {
 		return "expired"
 	}
 	h := int(d.Hours())
-	m := int(d.Minutes()) % 60
-	if h > 0 {
-		return fmt.Sprintf("%dh %dm", h, m)
+	mins := int(d.Minutes()) % 60
+	if m.uiConfig.DurationDays && h >= 24 {
+		return fmt.Sprintf("%dd %dh %dm", h/24, h%24, mins)
 	}
-	return fmt.Sprintf("%dm", m)
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, mins)
+	}
+	return fmt.Sprintf("%dm", mins)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -321,3 +321,14 @@ func TestBuildBarCellsWithoutPaceDataUsesNormalFill(t *testing.T) {
 func TestOverPaceColorKeepsRedBarsDistinct(t *testing.T) {
 	assert.Equal(t, brightRed, overPaceColor(red))
 }
+
+func TestTimeUntilDurationDays(t *testing.T) {
+	reset := time.Now().Add(127*time.Hour + 21*time.Minute + 30*time.Second)
+
+	plain := Model{}
+	assert.Equal(t, "127h 21m", plain.timeUntil(reset))
+
+	days := Model{uiConfig: config.UIConfig{DurationDays: true}}
+	assert.Equal(t, "5d 7h 21m", days.timeUntil(reset))
+	assert.Equal(t, "4h 57m", days.timeUntil(time.Now().Add(4*time.Hour+57*time.Minute+30*time.Second)))
+}

--- a/internal/tui/openrouter_standard_key_view.go
+++ b/internal/tui/openrouter_standard_key_view.go
@@ -20,11 +20,11 @@ func (m Model) renderORStandardBody(u *openrouter.Usage) string {
 			label = fmt.Sprintf("%-8s", periodLabel)
 			barCoversPeriod = true
 		}
-		info := truncate(u.Key.LimitReset, compactResetWidth)
+		info := truncate(u.Key.LimitReset, m.resetInfoWidth())
 		if hasPeriod {
 			info = fmt.Sprintf("$%.2f", u.Key.LimitRemaining)
 		}
-		b.WriteString(renderCompactBar(label, usedPct, -1, bw, info))
+		b.WriteString(m.renderCompactBar(label, usedPct, -1, bw, info))
 	}
 
 	parts := make([]string, 0, 3)


### PR DESCRIPTION
## Context
Codex and Claude meters show remaining time in a fixed "127h 21m" format; users tracking weekly limits may prefer seeing it broken out in days.

## Summary
- Add `ui.duration_days` config option (default `false`) under a new top-level `ui` section
- When enabled, reset countdowns ≥24h render as `5d 7h 21m` instead of `127h 21m`
- Widen the fixed reset-info column (8 → 10 chars) and shrink the compact bar accordingly so bars stay right-aligned across Claude, Codex, and OpenRouter sections