### PR TITLE
Handle dynamic Codex usage windows

### DIFF
--- a/internal/tui/codex_view.go
+++ b/internal/tui/codex_view.go
@@ -19,6 +19,19 @@ func (m Model) codexElapsedPercent(w *codex.UsageWindow) float64 {
 	return elapsedPercent(w.ResetTime(), time.Duration(w.LimitWindowSeconds)*time.Second)
 }
 
+func codexWindowLabel(w *codex.UsageWindow) string {
+	switch time.Duration(w.LimitWindowSeconds) * time.Second {
+	case 5 * time.Hour:
+		return "5h Limit"
+	case 7 * 24 * time.Hour:
+		return "Weekly  "
+	case 30 * 24 * time.Hour:
+		return "Monthly "
+	default:
+		return "Limit   "
+	}
+}
+
 func (m Model) codexSection() string {
 	return sectionBox("Codex", m.codexSectionBody(), m.width)
 }
@@ -71,12 +84,12 @@ func (m Model) codexSectionBody() string {
 	b.WriteByte('\n')
 
 	if w := u.RateLimit.PrimaryWindow; w != nil {
-		b.WriteString(m.renderCompactBar("5h Limit", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
+		b.WriteString(m.renderCompactBar(codexWindowLabel(w), w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 	}
 	if w := u.RateLimit.SecondaryWindow; w != nil {
-		b.WriteString(m.renderCompactBar("Weekly  ", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
+		b.WriteString(m.renderCompactBar(codexWindowLabel(w), w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 	}
-	if m.codexUIConfig.CodeReview {
+	if m.codexUIConfig.CodeReview && u.CodeReviewRateLimit != nil {
 		if w := u.CodeReviewRateLimit.PrimaryWindow; w != nil {
 			b.WriteString(m.renderCompactBar("Code Review", w.UsedPercent, m.codexElapsedPercent(w), bw, m.timeUntil(w.ResetTime())))
 		}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -55,7 +55,7 @@ func TestCodexSectionRenderSnapshot(t *testing.T) {
 					ResetAt:            now.Add(4 * 24 * time.Hour).Unix(),
 				},
 			},
-			CodeReviewRateLimit: codex.RateLimit{
+			CodeReviewRateLimit: &codex.RateLimit{
 				PrimaryWindow: &codex.UsageWindow{
 					UsedPercent:        90,
 					LimitWindowSeconds: 7 * 24 * 60 * 60,
@@ -82,6 +82,25 @@ func TestCodexSectionRenderSnapshot(t *testing.T) {
 	want, err := os.ReadFile(goldenPath)
 	require.NoError(t, err, "read golden")
 	assert.Equal(t, string(want), got, "codex section mismatch")
+}
+
+func TestCodexWindowLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int
+		want    string
+	}{
+		{name: "five hours", seconds: 5 * 60 * 60, want: "5h Limit"},
+		{name: "weekly", seconds: 7 * 24 * 60 * 60, want: "Weekly  "},
+		{name: "monthly", seconds: 30 * 24 * 60 * 60, want: "Monthly "},
+		{name: "unknown", seconds: 24 * 60 * 60, want: "Limit   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, codexWindowLabel(&codex.UsageWindow{LimitWindowSeconds: tt.seconds}))
+		})
+	}
 }
 
 func TestFormatClaudeTier(t *testing.T) {

--- a/pkg/codex/usage.go
+++ b/pkg/codex/usage.go
@@ -17,7 +17,7 @@ const LoginHint = "run `codex login` to sign in"
 type Usage struct {
 	PlanType            string       `json:"plan_type"`
 	RateLimit           RateLimit    `json:"rate_limit"`
-	CodeReviewRateLimit RateLimit    `json:"code_review_rate_limit"`
+	CodeReviewRateLimit *RateLimit   `json:"code_review_rate_limit"`
 	Credits             UsageCredits `json:"credits"`
 }
 

--- a/pkg/codex/usage_test.go
+++ b/pkg/codex/usage_test.go
@@ -1,0 +1,91 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageResponseUnmarshal(t *testing.T) {
+	tests := []struct {
+		name                 string
+		body                 string
+		primaryWindowSeconds int
+		hasSecondaryWindow   bool
+	}{
+		{
+			name: "five hour and weekly windows",
+			body: `{
+				"plan_type": "plus",
+				"rate_limit": {
+					"allowed": true,
+					"limit_reached": false,
+					"primary_window": {"used_percent": 42, "limit_window_seconds": 18000, "reset_after_seconds": 7200, "reset_at": 1784000000},
+					"secondary_window": {"used_percent": 75, "limit_window_seconds": 604800, "reset_after_seconds": 345600, "reset_at": 1784345600}
+				}
+			}`,
+			primaryWindowSeconds: 5 * 60 * 60,
+			hasSecondaryWindow:   true,
+		},
+		{
+			name: "weekly window only",
+			body: `{
+				"plan_type": "plus",
+				"rate_limit": {
+					"allowed": true,
+					"limit_reached": false,
+					"primary_window": {"used_percent": 0, "limit_window_seconds": 604800, "reset_after_seconds": 518740, "reset_at": 1784516033},
+					"secondary_window": null
+				},
+				"code_review_rate_limit": null,
+				"additional_rate_limits": null
+			}`,
+			primaryWindowSeconds: 7 * 24 * 60 * 60,
+			hasSecondaryWindow:   false,
+		},
+		{
+			name: "monthly window only",
+			body: `{
+				"plan_type": "enterprise",
+				"rate_limit": {
+					"allowed": true,
+					"limit_reached": false,
+					"primary_window": {"used_percent": 32, "limit_window_seconds": 2592000, "reset_after_seconds": 1209600, "reset_at": 1785729600},
+					"secondary_window": null
+				},
+				"code_review_rate_limit": null
+			}`,
+			primaryWindowSeconds: 30 * 24 * 60 * 60,
+			hasSecondaryWindow:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var usage Usage
+			require.NoError(t, json.Unmarshal([]byte(tt.body), &usage))
+			require.NotNil(t, usage.RateLimit.PrimaryWindow)
+			assert.Equal(t, tt.primaryWindowSeconds, usage.RateLimit.PrimaryWindow.LimitWindowSeconds)
+			assert.Equal(t, tt.hasSecondaryWindow, usage.RateLimit.SecondaryWindow != nil)
+			assert.Nil(t, usage.CodeReviewRateLimit)
+		})
+	}
+}
+
+func TestFetchUsageLive(t *testing.T) {
+	if os.Getenv("CODEX_LIVE_TEST") == "" {
+		t.Skip("CODEX_LIVE_TEST is not set")
+	}
+
+	auth, err := LoadAuth()
+	require.NoError(t, err)
+	usage, err := FetchUsage(auth)
+	require.NoError(t, err)
+
+	body, err := json.MarshalIndent(usage, "", "  ")
+	require.NoError(t, err)
+	t.Logf("decoded usage JSON:\n%s", body)
+}


### PR DESCRIPTION
## Context
Codex usage responses can now return a weekly or monthly limit as the only primary window, causing positional labels to report the wrong limit.

## Summary
- label Codex limits from their window duration instead of primary or secondary position
- support 5-hour, weekly, monthly, and unknown window durations
- preserve nullable code-review limits and cover legacy, weekly-only, and monthly-only JSON responses